### PR TITLE
강두오 4일차 문제 풀이

### DIFF
--- a/duoh/BOJ/src/java_1112/Main.java
+++ b/duoh/BOJ/src/java_1112/Main.java
@@ -1,0 +1,48 @@
+package java_1112;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class Main {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        int x = Integer.parseInt(st.nextToken());
+        int b = Integer.parseInt(st.nextToken());
+
+        System.out.println(convert(x, b));
+        br.close();
+    }
+
+    private static String convert(int x, int b) {
+        if (x == 0) {
+            return "0";
+        }
+
+        boolean flag = (x < 0 && b > 1);
+        if (flag) {
+            x = -x;
+        }
+
+        StringBuilder sb = new StringBuilder();
+        while (x != 0) {
+            int remainder = x % b;
+            x /= b;
+
+            if (remainder < 0) {
+                remainder += Math.abs(b);
+                x += 1;
+            }
+            sb.append(remainder);
+        }
+
+        if (flag) {
+            sb.append('-');
+        }
+
+        return sb.reverse().toString();
+    }
+}


### PR DESCRIPTION
## 풀이

### 풀이에 대한 직관적인 설명

- 10진수 `x`를 `b` 진법으로 변환하는 문제이다.
- 음수일 경우, 부호만 따로 저장하고 변환은 양수로 처리한다.


### 풀이 도출 과정

핵심은 나머지가 음수일 경우, 이를 양수로 보정하는 부분이다.

- 음수인 나머지가 발생하면, 진법 `b`의 절댓값을 더해 양수로 보정하고 몫을 1 증가시킴
- 변환된 값을 저장한 후, 뒤집어서 최종 결과를 출력


## 복잡도

* 시간복잡도: O(log x)

`x`를 0이 될 때까지 나누는 과정이 반복되므로, O(log x)

## 채점 결과

<img width="695" alt="스크린샷 2024-09-09 오후 7 16 52" src="https://github.com/user-attachments/assets/ee6cc3da-2b28-4f01-ba23-62fa2e3d0d12">