### PR TITLE
강두오 7일차 문제 풀이

### DIFF
--- a/duoh/BOJ/src/java_2473/Main.java
+++ b/duoh/BOJ/src/java_2473/Main.java
@@ -1,0 +1,58 @@
+package java_2473;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.StringTokenizer;
+
+public class Main {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        int N = Integer.parseInt(br.readLine());
+        int[] arr = new int[N];
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        for (int i = 0; i < N; i++) {
+            arr[i] = Integer.parseInt(st.nextToken());
+        }
+
+        Arrays.sort(arr);
+        findClosestSum(arr, N);
+        br.close();
+    }
+
+    private static void findClosestSum(int[] arr, int N) {
+        long min = Long.MAX_VALUE;
+        int a = 0, b = 0, c = 0;
+
+        for (int i = 0; i < N - 2; i++) {
+            int left = i + 1;
+            int right = N - 1;
+
+            while (left < right) {
+                long sum = (long) arr[i] + arr[left] + arr[right];
+
+                if (min > Math.abs(sum)) {
+                    min = Math.abs(sum);
+                    a = arr[i];
+                    b = arr[left];
+                    c = arr[right];
+                }
+
+                if (sum == 0) {
+                    break;
+                }
+
+                if (sum > 0) {
+                    right--;
+                } else {
+                    left++;
+                }
+            }
+        }
+
+        System.out.println(a + " " + b + " " + c);
+    }
+}


### PR DESCRIPTION
## 풀이

### 풀이에 대한 직관적인 설명

- 세 개의 숫자를 골라 합이 0에 가장 가까운 값을 찾는 문제이다.


### 풀이 도출 과정

핵심은 투 포인터를 사용하는 것이다. 완전탐색은 O(N^3)으로 시간 초과이다.

- 정렬된 배열에서 첫 숫자를 고정하고, 나머지 두 숫자는 `left`, `right`  투 포인터로 합이 0에 가까운 값을 찾는다.
- 세 숫자의 합 `sum`은 int 타입 범위를 벗어날 수 있어서, long 타입을 사용해야 한다.


## 복잡도

* 시간복잡도: O(N^2)
 각 숫자에 대해 투 포인터로 탐색 O(N^2)


## 채점 결과

<img width="685" alt="스크린샷 2024-09-14 오후 2 39 39" src="https://github.com/user-attachments/assets/fda3616d-1cce-4fc6-896e-12be4fbc76d9">