### PR TITLE
오동재 7일차 문제 풀이

### DIFF
--- a/dongjae/BOJ/src/java_1931/Main.java
+++ b/dongjae/BOJ/src/java_1931/Main.java
@@ -1,0 +1,66 @@
+package java_1931;
+
+import java.util.*;
+import java.io.*;
+
+class Node implements Comparable<Node> {
+    private int start;
+    private int end;
+
+    public Node(int start, int end) {
+        this.start = start;
+        this.end = end;
+    }
+
+    public int getStart() {
+        return this.start;
+    }
+
+    public int getEnd() {
+        return this.end;
+    }
+
+    @Override
+    public int compareTo(Node other) {
+        if (this.end < other.end ) return -1;
+        else if (this.end == other.end) {
+            if (this.start < other.start) return -1;
+            else return 1;
+        } else return 1;
+    }
+}
+
+public class Main {
+    public static int n;
+    public static List<Node> array = new ArrayList<>();
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        n = Integer.parseInt(br.readLine());
+
+        StringTokenizer st;
+
+        for (int i = 0; i < n; i++) {
+            st = new StringTokenizer(br.readLine());
+            int start = Integer.parseInt(st.nextToken());
+            int end = Integer.parseInt(st.nextToken());
+
+            array.add(new Node(start, end));
+        }
+
+        Collections.sort(array);
+
+        int count = 0;
+        int prevEnd = 0;
+
+        for (int i = 0; i < n; i++) {
+            if (prevEnd <= array.get(i).getStart()) {
+                prevEnd = array.get(i).getEnd();
+                count++;
+            }
+        }
+
+        System.out.println(count);
+    }
+}


### PR DESCRIPTION
## 풀이

### 풀이에 대한 직관적인 설명

* 최대한 많은 회의를 하게 하려면 종료시간이 빠른 순서대로 회의를 먼저 정렬한다

### 풀이 도출 과정

* 종료시간이 빠른 순서대로 회의를 선택하되 겹치지 않도록 한다.
* 즉 `앞 회의 종료시간` <= `뒷 회의 시작시간`

## 복잡도

<!-- 푼 알고리즘에 대한 시간복잡도 작성 -->

* 시간복잡도: O(nlogn)

<!-- 위와 같이 복잡도를 산정하게 된 이유 --> 

종료시간에 따른 정렬의 시간복잡도 O(nlogn)

## 채점 결과

<!-- 문제 푼 결과 캡처 -->

<img width="857" alt="Screenshot 2024-09-14 at 5 36 37 PM" src="https://github.com/user-attachments/assets/a5f2820e-38de-4785-929a-c28701a710b8">