### PR TITLE
정다연 6일차 문제 풀이

### DIFF
--- a/dayeon/BOJ/src/java_5585/Main.java
+++ b/dayeon/BOJ/src/java_5585/Main.java
@@ -1,0 +1,26 @@
+package java_5585;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+public class Main {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int n = Integer.parseInt(br.readLine());
+
+        count(1000 - n);
+        br.close();
+    }
+    private static void count(int n) {
+        int sum = 0;
+        sum += n / 500; n %= 500; // 500엔
+        sum += n / 100; n %= 100; // 100엔
+        sum += n / 50; n %= 50; // 50엔
+        sum += n / 10; n %= 10; // 10엔
+        sum += n / 5; n %= 5; // 5엔
+        sum += n; // 1엔
+
+        System.out.print(sum);
+    }
+}


### PR DESCRIPTION
## 풀이

### 풀이에 대한 직관적인 설명
- 500엔부터 1엔까지 거슬러 줄 수 있는 만큼 거슬러주고 그 합을 계산

### 풀이 도출 과정
- 500엔부터 1엔까지 /로 거스름돈 개수를 sum에 저장
- 500엔부터 5엔까지 거슬러주고 남은 돈을 n에 저장

## 복잡도

* 시간복잡도
O(1)

## 채점 결과

<img width="1153" alt="6일차" src="https://github.com/user-attachments/assets/5b8a4bd9-cf05-4195-b514-87c4aa3b0522">
