### PR TITLE
강두오 9일차 문제 풀이

### DIFF
--- a/duoh/BOJ/src/java_7983/Main.java
+++ b/duoh/BOJ/src/java_7983/Main.java
@@ -1,0 +1,38 @@
+package java_7983;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.PriorityQueue;
+import java.util.StringTokenizer;
+
+public class Main {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        int n = Integer.parseInt(br.readLine());
+        StringTokenizer st;
+        PriorityQueue<int[]> pq = new PriorityQueue<>((o1, o2) -> o2[1] - o1[1]);
+
+        for (int i = 0; i < n; i++) {
+            st = new StringTokenizer(br.readLine());
+            int d = Integer.parseInt(st.nextToken());
+            int t = Integer.parseInt(st.nextToken());
+
+            pq.offer(new int[] {d, t});
+        }
+
+        int last = Integer.MAX_VALUE;
+
+        while (!pq.isEmpty()) {
+            int[] cur = pq.poll();
+            int d = cur[0];
+            int t = cur[1];
+
+            last = Math.min(last, t) - d;
+        }
+
+        System.out.println(last);
+        br.close();
+    }
+}


### PR DESCRIPTION
## 풀이

### 풀이에 대한 직관적인 설명

- 기한(`t`) 기준 내림차순 정렬, 가능한 가장 늦은 시작 시간(`last`)을 계산하는 문제이다.


### 풀이 도출 과정

- `t`와 `last` 중 작은 값을 선택하고, 그 값에서 걸리는 기간(`d`)를 뺀 값으로 갱신


## 복잡도

* 시간복잡도: O(N log N)
우선순위 큐 삽입, 삭제에 O(log N), `n`개의 작업을 처리하므로 O(N log N)


## 채점 결과

<img width="720" alt="스크린샷 2024-09-17 오후 8 18 35" src="https://github.com/user-attachments/assets/89eaa60e-23c0-485e-9485-188acb7f990b">

(`상단`) 배열 풀이 / (`하단`) 우선순위 큐 풀이 이고, 배열 풀이가 시간이 더 많이 소요된 걸 볼 수 있다.
원소 삽입 / 삭제가 빈번하다면 우선순위 큐 사용이 효율적이다.