### PR TITLE
오동재 9일차 문제 풀이

### DIFF
--- a/dongjae/BOJ/src/java_1339/Main.java
+++ b/dongjae/BOJ/src/java_1339/Main.java
@@ -1,0 +1,42 @@
+package java_1339;
+
+import java.util.*;
+import java.io.*;
+
+public class Main {
+    public static int n;
+    public static String[] words;
+    public static int[] alphaWeights = new int[26];
+    public static List<Integer> weights = new ArrayList<>();
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        n = Integer.parseInt(br.readLine());
+
+        words = new String[n];
+
+        for (int i = 0; i < n; i++) {
+            words[i] = br.readLine();
+            for (int j = 0; j < words[i].length(); j++) {
+                char now = words[i].charAt(j);
+                alphaWeights[(int)(now - 'A')] += (int) Math.pow(10, words[i].length() - 1 - j);
+            }
+        }
+
+        for (int i = 0; i < alphaWeights.length; i++) {
+            if (alphaWeights[i] > 0) {
+                weights.add(alphaWeights[i]);
+            }
+        }
+
+        weights.sort(Collections.reverseOrder());
+
+        int result = 0;
+        int num = 9;
+        for (int weight : weights) {
+            result += weight * num--;
+        }
+
+        System.out.println(result);
+    }
+}


### PR DESCRIPTION
## 풀이

### 풀이에 대한 직관적인 설명

단어별로 가중치를 부여하는 로직이 중요함

### 풀이 도출 과정

배열을 자유자재로 다룰 수 있어야 풀기 쉬운 문제로 `가중치`를 무엇으로 설정하느냐에 따라 풀이 방법이 천차만별이다.
* 처음에는 가중치를 `10의 자릿수`로 설정하였다.
* 하지만 계산이 복잡해졌고, 이 대신에 `계산된 자릿수의 총 합`으로 변경하였다.
  * 예를 들어 A라는 단어가 1000의 자리, 100의 자리에 총 2번 등장했다면 가중치는 1100이 된다.
* 이렇게 가중치를 구하고 가중치 배열을 내림차순으로 정렬한 후, 9부터 내림차순으로 해당 수를 곱하여 결과에 더하면 된다.

## 복잡도

<!-- 푼 알고리즘에 대한 시간복잡도 작성 -->

* 시간복잡도: O(n^2)

<!-- 위와 같이 복잡도를 산정하게 된 이유 --> 

n개의 단어 하나당 포함되는 글자를 모두 순회해서 조사해야 하므로 O(n^2)
단, 단어는 최대 10개이고 한 단어당 최대 글자 길이는 8이므로 최악의 경우 80번의 연산을 수행하므로 시간 제한 내에 풀이 가능

## 채점 결과

<!-- 문제 푼 결과 캡처 -->

<img width="857" alt="Screenshot 2024-09-18 at 9 26 26 AM" src="https://github.com/user-attachments/assets/4b521a6a-1916-4822-bc7b-66bed71bc489">
