### PR TITLE
오동재 10일차 문제 풀이

### DIFF
--- a/dongjae/BOJ/src/java_11000/Main.java
+++ b/dongjae/BOJ/src/java_11000/Main.java
@@ -1,0 +1,63 @@
+package java_11000;
+
+import java.util.*;
+import java.io.*;
+
+class Lecture implements Comparable<Lecture> {
+    private int start;
+    private int end;
+
+    public Lecture(int start, int end) {
+        this.start = start;
+        this.end = end;
+    }
+
+    public int getStart() {
+        return this.start;
+    }
+
+    public int getEnd() {
+        return this.end;
+    }
+
+    @Override
+    public int compareTo(Lecture other) {
+        if (this.start < other.start) return -1;
+        else if (this.start == other.start) {
+            if (this.end < other.end) return -1;
+            else return 1;
+        } else return 1;
+    }
+}
+
+public class Main {
+    public static int n;
+    public static List<Lecture> array = new ArrayList<>();
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        n = Integer.parseInt(br.readLine());
+
+        StringTokenizer st;
+        for (int i = 0; i < n; i++) {
+            st = new StringTokenizer(br.readLine());
+            int start = Integer.parseInt(st.nextToken());
+            int end = Integer.parseInt(st.nextToken());
+            array.add(new Lecture(start, end));
+        }
+
+        Collections.sort(array);
+
+        PriorityQueue<Integer> pq = new PriorityQueue<>();
+
+        pq.offer(array.get(0).getEnd());
+        for (int i = 1; i < n; i++) {
+            if (!pq.isEmpty() && pq.peek() <= array.get(i).getStart()) {
+                pq.poll();
+            }
+            pq.offer(array.get(i).getEnd());
+        }
+
+        System.out.println(pq.size());
+    }
+}


### PR DESCRIPTION
## 풀이

### 풀이에 대한 직관적인 설명

시작 시간이 가장 빠른 순서대로 강의를 선택하되, 이전 강의의 종료 시간보다 빠르지 않은 것으로 강의실을 배정

### 풀이 도출 과정

* 시작 시간 순서대로 강의를 정렬한다.
* 우선순위 큐(오름차순)에 시작 시간이 가장 빠른 강의의 종료시간을 삽입한다.
* 우선순위 큐의 top에 있는 강의의 종료시간(가장 빨리 끝나는 강의)가 다음 강의 시작 시간보다 이를 경우 poll 한다.
* 다음 강의의 종료시간을 우선순위 큐에 삽입한다.

사용해야 하는 최소 강의실 개수는 우선순위 큐의 `.size()`이다.

## 복잡도

<!-- 푼 알고리즘에 대한 시간복잡도 작성 -->

* 시간복잡도: O(nlogn)

<!-- 위와 같이 복잡도를 산정하게 된 이유 --> 

강의를 시간 순서대로 정렬하는데 걸리는 시간 O(nlogn), 우선순위 큐 삽입과 삭제 연산 하나당 O(logn)인데 n개 이므로 O(nlogn).

## 채점 결과

<!-- 문제 푼 결과 캡처 -->

<img width="856" alt="Screenshot 2024-09-19 at 4 34 35 PM" src="https://github.com/user-attachments/assets/1632f1b3-b0cf-4048-8075-2ccb222e9799">
