### PR TITLE
강두오 10일차 문제 풀이

### DIFF
--- a/duoh/BOJ/src/java_1132/Main.java
+++ b/duoh/BOJ/src/java_1132/Main.java
@@ -1,0 +1,49 @@
+package java_1132;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.io.IOException;
+import java.util.Arrays;
+
+public class Main {
+    private static final int SIZE = 10;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        int N = Integer.parseInt(br.readLine());
+        long[] alpha = new long[SIZE];
+        boolean[] notZero = new boolean[SIZE];
+
+        for (int i = 0; i < N; i++) {
+            char[] ch = br.readLine().toCharArray();
+            int len = ch.length - 1;
+            notZero[ch[0] - 'A'] = true;
+
+            for (int j = 0; j <= len; j++) {
+                alpha[ch[j] - 'A'] += (long) Math.pow(10, len - j);
+            }
+        }
+
+        long min = Long.MAX_VALUE;
+        int minIdx = -1;
+
+        for (int i = 0; i < SIZE; i++) {
+            if (!notZero[i] && alpha[i] < min) {
+                min = alpha[i];
+                minIdx = i;
+            }
+        }
+
+        alpha[minIdx] = 0;
+        Arrays.sort(alpha);
+        long ans = 0, mul = 9;
+
+        for (int i = SIZE - 1; i >= 0; i--) {
+            ans += alpha[i] * mul--;
+        }
+
+        System.out.println(ans);
+        br.close();
+    }
+}


### PR DESCRIPTION
## 풀이

### 풀이에 대한 직관적인 설명

- `A`~ `J` 각 알파벳의 자릿수에 따른 가중치를 계산하고, 가능한 최대 합을 구하는 문제이다.
- 단, 선행 문자에는 0이 할당될 수 없다.

### 풀이 도출 과정

핵심은 선행이 아닌 알파벳 중 가장 작은 값에 0을 할당하는 것이다.

- 각 문자열을 `char[]` 로 받아서 알파벳별 자릿수에 따른 가중치를 계산함
- 선행 문자에는 0이 할당될 수 없으므로, `boolean[]` 배열로 체크해줌
- 선행 문자가 아니면서 가중치가 가장 작은 값을 찾아 0을 할당함
- 정렬하고, 큰 가중치에 큰 수부터 할당해서 계산함


## 복잡도

* 시간복잡도: O(N * M)
문자열 `N <= 50`, 수의 길이 `M <= 12`


## 채점 결과

<img width="938" alt="스크린샷 2024-09-19 오후 8 21 13" src="https://github.com/user-attachments/assets/213bbdfe-dd54-4e7a-9b26-0521c39a9471">
