### PR TITLE
오동재 11일차 문제 풀이

### DIFF
--- a/dongjae/BOJ/src/java_1202/Main.java
+++ b/dongjae/BOJ/src/java_1202/Main.java
@@ -1,0 +1,78 @@
+package java_1202;
+
+import java.util.*;
+import java.io.*;
+
+class Node implements Comparable<Node> {
+    private int m;
+    private int v;
+
+    public Node(int m, int v) {
+        this.m = m;
+        this.v = v;
+    }
+
+    public int getM() {
+        return this.m;
+    }
+
+    public int getV() {
+        return this.v;
+    }
+
+    @Override
+    public int compareTo(Node other) {
+        if (this.m < other.m) return -1;
+        else if (this.m == other.m) {
+            if (this.v < other.v) return 1;
+            else if (this.v == other.v) return 0;
+            else return -1;
+        } else return 1;
+    }
+}
+
+public class Main {
+    public static int n, k;
+    public static List<Node> array = new ArrayList<>();
+    public static List<Integer> bags = new ArrayList<>();
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        n = Integer.parseInt(st.nextToken());
+        k = Integer.parseInt(st.nextToken());
+
+        for (int i = 0; i < n; i++) {
+            st = new StringTokenizer(br.readLine());
+            int weight = Integer.parseInt(st.nextToken());
+            int value = Integer.parseInt(st.nextToken());
+            array.add(new Node(weight, value));
+        }
+
+        for (int i = 0; i < k; i++) {
+            st = new StringTokenizer(br.readLine());
+            bags.add(Integer.parseInt(st.nextToken()));
+        }
+
+        Collections.sort(array);
+        Collections.sort(bags);
+
+        long result = 0;
+        int idx = 0;
+
+        PriorityQueue<Integer> pq = new PriorityQueue<>(Collections.reverseOrder());
+        for (int i = 0; i < k; i++) {
+            while (idx < n && array.get(idx).getM() <= bags.get(i)) {
+                pq.offer(array.get(idx).getV());
+                idx++;
+            }
+
+            if (!pq.isEmpty()) {
+                result += pq.poll();
+            }
+        }
+
+        System.out.println(result);
+    }
+}


### PR DESCRIPTION
## 풀이

### 풀이에 대한 직관적인 설명

가방마다 담길 수 있는 모든 보석을 우선 순위 큐에 삽입하고 거기서 가장 비싼 보석을 고른다.

### 풀이 도출 과정

* 가방과 보석을 무게에 따라 오름차순으로 정렬하고 한 가방에 담길 수 있는 보석들을 선택할 때 이전 가방에서 골랐었던 보석들은 제외한다.
* 실수한 부분이 두 가지가 있었는데 하나는 보석의 총합, 즉 `result` 변수를 `int` 타입으로 선언한 것이다.
  * `int`는 32비트이고, `long`은 64비트이므로 저장할 수 있는 수가 대략 10의 9제곱이 넘어가면 `long`타입으로 선언해야한다.
  * 두번째로 실수한 부분은 `Comparable` 인터페이스를 구현할 때 `compareTo` 메소드에서 케이스 분류를 명확히 하지 않았다.
  * 즉 무게도 같고, 가격도 같은 보석은 0을 반환하도록 해야하는데 `if-else` 로만 처리하는 바람에 이를 구현하지 않았다.

## 복잡도

<!-- 푼 알고리즘에 대한 시간복잡도 작성 -->

* 시간복잡도: O(nlogn)

<!-- 위와 같이 복잡도를 산정하게 된 이유 --> 

정렬, 우선순위 큐 삽입에서 O(nlogn)을 넘는 연산이 존재하지 않는다.

## 채점 결과

<!-- 문제 푼 결과 캡처 -->

<img width="856" alt="Screenshot 2024-09-20 at 5 19 19 PM" src="https://github.com/user-attachments/assets/333a145c-8429-4d89-a5b2-5cc3fca14ae6">
