### PR TITLE
오동재 12일차 문제 풀이

### DIFF
--- a/dongjae/BOJ/src/java_2437/Main.java
+++ b/dongjae/BOJ/src/java_2437/Main.java
@@ -1,0 +1,31 @@
+package java_2437;
+
+import java.util.*;
+import java.io.*;
+
+public class Main {
+    public static int n;
+    public static int[] array;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        n = Integer.parseInt(br.readLine());
+
+        array = new int[n];
+
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        for (int i = 0; i < n; i++) {
+            array[i] = Integer.parseInt(st.nextToken());
+        }
+
+        Arrays.sort(array);
+
+        int sum = 0;
+        for (int i = 0; i < n; i++) {
+            if (sum + 1 < array[i]) break;
+            sum += array[i];
+        }
+
+        System.out.println(sum + 1);
+    }
+}


### PR DESCRIPTION
## 풀이

### 풀이에 대한 직관적인 설명

배열을 정렬하고 누적합을 하나씩 구할 때 다음 원소의 값이 누적합 + 1보다 작다면 1부터 누적합 + 1까지의 모든 수는 구할 수 있다.

### 풀이 도출 과정

* 예를 들어 `1 1 2 3`의 배열이 있다고 가정했을 때 `1 1 2`의 누적합 4보다 3이 작기 때문에 5까지의 모든 수를 구할 수 있다.
  * `1`, `2`, `1+2`, `3+1`, `3+2`
* 따라서 다음 원소의 값이 누적합 + 1보다 클 때 만들 수 없는 양의 정수 최솟값은 당시의 누적합 + 1이다.

## 복잡도

<!-- 푼 알고리즘에 대한 시간복잡도 작성 -->

* 시간복잡도: O(nlogn)

<!-- 위와 같이 복잡도를 산정하게 된 이유 --> 

정렬에 소요되는 연산이 가장 큰 복잡도를 가진다.

## 채점 결과

<!-- 문제 푼 결과 캡처 -->

<img width="860" alt="Screenshot 2024-09-21 at 4 11 32 PM" src="https://github.com/user-attachments/assets/aa5eb712-0512-460b-b192-8d5733cdffc4">