### PR TITLE
강두오 11일차 문제 풀이

### DIFF
--- a/duoh/BOJ/src/java_1464/Main.java
+++ b/duoh/BOJ/src/java_1464/Main.java
@@ -1,0 +1,35 @@
+package java_1464;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayDeque;
+import java.util.Deque;
+
+public class Main {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        char[] S = br.readLine().toCharArray();
+        final int len = S.length;
+
+        Deque<Character> deque = new ArrayDeque<>();
+        deque.offer(S[0]);
+
+        for (int i = 1; i < len; i++) {
+            if (deque.peekLast() < S[i]) {
+                deque.offerFirst(S[i]);
+            } else {
+                deque.offer(S[i]);
+            }
+        }
+
+        StringBuilder sb = new StringBuilder();
+        while (!deque.isEmpty()) {
+            sb.append(deque.pollLast());
+        }
+
+        System.out.println(sb);
+        br.close();
+    }
+}


### PR DESCRIPTION
## 풀이

### 풀이에 대한 직관적인 설명

- `deque`를 사용하여 앞뒤로 삽입하면서 사전순으로 가장 앞서는 것을 구하는 문제이다.


### 풀이 도출 과정

핵심은 `deque`를 이해하고 있는가이다.

-  `deque`의 마지막 문자와 비교하여 크면 앞에, 아니라면 뒤에 삽입함
- `deque`에 담긴 문자를 뒤부터 빼내서 사전순으로 제일 앞서는 결과를 만듦


## 복잡도

* 시간복잡도: O(N)
N개의 문자를 순차적으로 deque에 삽입함. 각 삽입 연산은 O(1)이므로, O(N)


## 채점 결과
<img width="938" alt="스크린샷 2024-09-22 오후 9 09 38" src="https://github.com/user-attachments/assets/43ffe00c-0cf8-4e79-b608-b7485f271c43">
