### PR TITLE
오동재 14일차 문제 풀이

### DIFF
--- a/dongjae/BOJ/src/java_1717/Main.java
+++ b/dongjae/BOJ/src/java_1717/Main.java
@@ -1,0 +1,58 @@
+package java_1717;
+
+import java.util.*;
+import java.io.*;
+
+public class Main {
+    public static int n, m;
+    public static int[] parent;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        n = Integer.parseInt(st.nextToken());
+        m = Integer.parseInt(st.nextToken());
+
+        parent = new int[n+1];
+        for (int i = 0; i < n+1; i++) {
+            parent[i] = i;
+        }
+
+        StringBuilder sb = new StringBuilder();
+
+        for (int i = 0; i < m; i++) {
+            st = new StringTokenizer(br.readLine());
+            int x = Integer.parseInt(st.nextToken());
+            int a = Integer.parseInt(st.nextToken());
+            int b = Integer.parseInt(st.nextToken());
+
+            if (x == 0) unionParent(a, b);
+
+            if (x == 1) {
+                if (findParent(a) == findParent(b)) {
+                    sb.append("YES").append("\n");
+                } else {
+                    sb.append("NO").append("\n");
+                }
+            }
+        }
+
+        System.out.println(sb);
+    }
+
+    public static int findParent(int x) {
+        if (x == parent[x]) return x;
+        else {
+            parent[x] = findParent(parent[x]);
+            return parent[x];
+        }
+    }
+
+    public static void unionParent(int x, int y) {
+        int xP = findParent(x);
+        int yP = findParent(y);
+        if (xP < yP) parent[yP] = xP;
+        else parent[xP] = yP;
+    }
+}


### PR DESCRIPTION
## 풀이

### 풀이에 대한 직관적인 설명

집합의 연산 중 부모 찾기 연산과 합집합 연산을 코드로 구현한다. 이를 서로소 집합 자료구조 또는 `union-find`라고 부르기도 한다.

### 풀이 도출 과정

서로소 집합 자료구조는 트리 알고리즘에서도 자주 등장하는 개념이다. 먼저 합집합 연산은 다음과 같다.
* 합치고자 하는 두 노드 A, B를 확인한다.
  * A와 B의 루트 노드 A'과 B'을 각각 찾는다.
  * A'를 B'의 부모 노드로 설정한다(B'가 A'를 가리키도록 한다).
* 모든 합집합 연산을 처리할 때까지 위 과정을 반복한다.

부모 찾기(루트 노드) 연산은 다음과 같다.
* 찾고자 하는 노드 A를 입력하고 A가 루트노드인지 확인하다.
* 루트노드일 경우 A를 반환하고 아닐 경우 해당 함수를 재귀적으로 호출한다.

## 복잡도

<!-- 푼 알고리즘에 대한 시간복잡도 작성 -->

* 시간복잡도: O(m)

<!-- 위와 같이 복잡도를 산정하게 된 이유 -->

총 m 번의 `unionParent` 또는 `findParent`의 연산을 수행하게 되는데, 해당 함수들은 경로 압축 기법을 기반으로 하기 때문에 한 번 호출 때마다 `O(α(n))`의 시간이 걸린다. 여기서 `α(n)`은 아커만 함수의 역함수로 매우 느리게 증가하는 함수, 즉 상수 시간에 가깝기 때문에 시간 복잡도는 m의 크기에 의존적이다.

## 채점 결과

<!-- 문제 푼 결과 캡처 -->

<img width="856" alt="Screenshot 2024-09-25 at 3 15 07 PM" src="https://github.com/user-attachments/assets/0255742f-91f1-41d6-a726-361e53646a78">
