### PR TITLE
강두오 13일차 문제 풀이

### DIFF
--- a/duoh/BOJ/src/java_6137/Main.java
+++ b/duoh/BOJ/src/java_6137/Main.java
@@ -1,0 +1,58 @@
+package java_6137;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+public class Main {
+    private static final int LINE = 80;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        int N = Integer.parseInt(br.readLine());
+        char[] S = new char[N];
+        for (int i = 0; i < N; i++) {
+            S[i] = br.readLine().charAt(0);
+        }
+
+        int count = 0, left = 0, right = N - 1;
+        StringBuilder sb = new StringBuilder();
+
+        while (left <= right) {
+            boolean flag = false;
+
+            if (S[left] == S[right]) {
+                int l = left + 1, r = right - 1;
+
+                while (l <= r) {
+                    if (S[l] < S[r]) {
+                        flag = true;
+                        break;
+                    } else if (S[l] > S[r]) {
+                        break;
+                    }
+                    l++; r--;
+                }
+            } else {
+                flag = S[left] < S[right];
+            }
+
+            if (flag) {
+                sb.append(S[left]);
+                left++;
+            } else {
+                sb.append(S[right]);
+                right--;
+            }
+            count++;
+
+            if (count % LINE == 0) {
+                sb.append("\n");
+            }
+        }
+
+        System.out.println(sb);
+        br.close();
+    }
+}


### PR DESCRIPTION
## 풀이

### 풀이에 대한 직관적인 설명

- 문자열 `S`의 왼쪽 또는 오른쪽 문자를 하나씩 선택하여 사전순으로 가장 빠른 문자열을 만드는 문제이다.
- 단, 80글자마다 새줄 문자를 출력해야 된다.


### 풀이 도출 과정

핵심은 왼쪽과 오른쪽 문자가 동일할 경우, 그 다음 문자를 계속 비교하여 조건 처리를 해야된다는 것이다.

- 왼쪽과 오른쪽 문자를 비교하여 더 작은 문자를 선택
- 80글자마다 새줄 문자 출력해야 함
   처음에는 `sb.length()`로 풀었는데, 문자만 카운트해야 한다는 점을 고려하지 못함..
   이후, 문자열에 추가된 글자를 직접 카운트하는 방식으로 수정함

번외) 이것저것 시도해보다가 `sb.length() > 0`으로 비어있는 경우 예외 처리를 했었는데, 인텔리제이가 `!sb.isEmpty()`를 제안했다. (컴파일 에러 발생)
찾아보니, CharSequence에 `isEmpty()` 메서드는 java 15에서 도입됐다고 하더라..


## 복잡도

* 시간복잡도: O(n^2)
앞 뒤의 문자가 동일할 경우 다음 문자를 계속 비교한다.
최악의 경우 문자열 길이 `N`에 대해 `N/2`번 비교가 발생하므로 O(n^2)

## 채점 결과

<img width="939" alt="스크린샷 2024-09-25 오후 2 11 53" src="https://github.com/user-attachments/assets/5eed776e-bc83-475f-8561-39af7c9d93a0">
