### PR TITLE
김신희 9일차 문제 풀이

### DIFF
--- a/shinhee/BOJ/src/java_7568/Main.java
+++ b/shinhee/BOJ/src/java_7568/Main.java
@@ -1,0 +1,33 @@
+package BOJ.src.java_7568;
+
+import java.io.*;
+
+public class Main {
+    public static void main(String[] args) throws IOException {
+        // 키, 몸무개 -> 등수 (x, y)
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        int N = Integer.parseInt(br.readLine());
+        int[][] arr = new int[N][2];
+
+        String[] str;
+        for (int i = 0; i < N; i++) {
+            str = br.readLine().split(" ");
+            arr[i][0] = Integer.parseInt(str[0]);
+            arr[i][1] = Integer.parseInt(str[1]);
+        }
+
+        StringBuilder sb = new StringBuilder();
+
+        for (int i = 0; i < N; i++) {
+            int rank = 1;
+            for (int j = 0; j < N; j++) {
+                if (arr[i][0] < arr[j][0] && arr[i][1] < arr[j][1]){
+                    rank++;
+                }
+            }
+            sb.append(rank).append(" ");
+        }
+        System.out.println(sb);
+    }
+}


### PR DESCRIPTION
## 풀이

### 풀이에 대한 직관적인 설명
2차원 배열로 키와 무게를 저장, 이중 반복문으로 비교하여 등수 매기기

### 풀이 도출 과정
1. 입력 받기: 먼저 각 사람의 키와 몸무게를 배열에 저장.
2. 등수 계산: 각 사람을 기준으로 나머지 사람들과 비교. 다른 사람이 자신보다 키와 몸무게가 둘 다 크면 해당 사람의 등수가 높아지므로, 등수를 1씩 증가
3. 결과 출력: 계산된 등수를 문자열로 저장하여 마지막에 한 번에 출력

## 복잡도

* 시간복잡도: O(n^2)
사람의 덩치를 순회하여 모두 비교하기 때문에 이중 루프

## 채점 결과

![image](https://github.com/user-attachments/assets/cafa7082-d39c-4397-bdf2-385530a76e21)