### PR TITLE
정다연 13일차 문제 풀이

### DIFF
--- a/dayeon/BOJ/src/java_32141/Main.java
+++ b/dayeon/BOJ/src/java_32141/Main.java
@@ -1,0 +1,36 @@
+package java_32141;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class Main {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        int N = Integer.parseInt(st.nextToken());
+        int H = Integer.parseInt(st.nextToken());
+
+        int[] cards = new int[N];
+        st = new StringTokenizer(br.readLine());
+        for (int i = 0; i < N; i++) {
+            cards[i] = Integer.parseInt(st.nextToken());
+        }
+        System.out.println(battle(cards, H));
+    }
+    private static int battle(int[] cards, int H) {
+        int sum = 0;
+        int count = 0;
+        for (int i = 0; i < cards.length; i++) {
+            if (sum + cards[i] < H) {
+                sum += cards[i];
+                count++;
+            } else {
+                count++;
+                return count;
+            }
+        }
+        return -1;
+    }
+}


### PR DESCRIPTION
## 풀이

### 풀이에 대한 직관적인 설명
- 카드를 순서대로 더하며 (현재 총합+현재 카드) 값과 상대 체력을 비교하며 횟수 카운트

### 풀이 도출 과정
- 모든 카드를 더해도 상대를 이길 수 없는 경우를 위해 return을 사용
- 현재의 총합(sum)과 현재 카드(cards[i])를 더한 값이 -> 체력보다 작다면 카드 더하고 횟수+ / 체력보다 크다면 횟수만+ 횟수 return 
- 카드를 다 더하고도 이길 수 없다면 return -1


## 복잡도
* 시간복잡도
O(n)

## 채점 결과
<img width="1152" alt="13일차" src="https://github.com/user-attachments/assets/8007c87e-bf55-4514-b58d-8b93686cbb8f">
