### PR TITLE
오동재 20일차 문제 풀이

### DIFF
--- a/dongjae/BOJ/src/java_2812/Main.java
+++ b/dongjae/BOJ/src/java_2812/Main.java
@@ -1,0 +1,34 @@
+package java_2812;
+
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    public static int n, k;
+    public static Stack<Integer> stack = new Stack<>();
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        n = Integer.parseInt(st.nextToken());
+        k = Integer.parseInt(st.nextToken());
+
+        String str = br.readLine();
+        for (int i = 0; i < n; i++) {
+            int now = str.charAt(i) - '0';
+            while (k > 0 && !stack.isEmpty() && stack.peek() < now) {
+                stack.pop();
+                k--;
+            }
+            stack.push(now);
+        }
+
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < stack.size() - k; i++) {
+            sb.append(stack.get(i));
+        }
+
+        System.out.println(sb);
+    }
+}


### PR DESCRIPTION
## 풀이

### 풀이에 대한 직관적인 설명

삽입하려는 숫자가 스택의 탑에 담겨져 있는 수보다 클 작거나 없을 때까지 스택을 pop한다.

### 풀이 도출 과정

아이디어를 떠올리는 데 시간이 걸렸다. 처음에는 가장 큰 자릿수에 올 수 있는 숫자 후보들을 모두 우선순위 큐에 삽입하고 최대값을 구하는 방식으로 차례대로 구하려고 했으나 구현에서 막혔다. 무엇보다 카테고리가 스택이어서 스택을 이용한 방식이 궁금해서 찾아봤는데 그리디의 성격을 지니는 풀이 방식이 눈에 띄었다.

특히 마지막 처리 부분이 까다로웠는데 `5555`와 같은 배열에서 2번만 삭제할 수 있는 상황에서 위 로직은 `55`대신 `5555`를 반환한다. 따라서 마지막 처리에서 k가 0이 아닐 경우 `stack.size() - k` 만큼만 앞에서부터 출력해야한다.

## 복잡도

<!-- 푼 알고리즘에 대한 시간복잡도 작성 -->

* 시간복잡도: O(n)

<!-- 위와 같이 복잡도를 산정하게 된 이유 --> 

구조는 이중반복문이지만 한 숫자당 스택에 최대 한번씩만 삽입되고 삭제되기 때문에 선형 시간에 비례한 O(n)

## 채점 결과

<!-- 문제 푼 결과 캡처 -->

<img width="858" alt="Screenshot 2024-10-02 at 4 39 20 PM" src="https://github.com/user-attachments/assets/85828897-eccf-4a24-9932-0896990076fa">