### PR TITLE
오동재 21일차 문제 풀이

### DIFF
--- a/dongjae/BOJ/src/java_17299/Main.java
+++ b/dongjae/BOJ/src/java_17299/Main.java
@@ -1,0 +1,69 @@
+package java_17299;
+
+import java.util.*;
+import java.io.*;
+
+class Node {
+    private int num;
+    private int count;
+
+    public Node(int num, int count) {
+        this.num = num;
+        this.count = count;
+    }
+
+    public int getNum() {
+        return this.num;
+    }
+
+    public int getCount() {
+        return this.count;
+    }
+}
+
+public class Main {
+    public static int n;
+    public static int[] array;
+    public static int[] countArr = new int[1000001];
+    public static List<Node> infoArr = new ArrayList<>();
+    public static Stack<Integer> stack = new Stack<>();
+    public static int[] result;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        n = Integer.parseInt(br.readLine());
+
+        array = new int[n];
+        result = new int[n];
+
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        for (int i = 0; i < n; i++) {
+            int now = Integer.parseInt(st.nextToken());
+            array[i] = now;
+            countArr[now]++;
+        }
+
+        for (int i = 0; i < n; i++) {
+            infoArr.add(new Node(array[i], countArr[array[i]]));
+        }
+
+        stack.push(0);
+        for (int i = 1; i < n; i++) {
+            while (!stack.isEmpty() && infoArr.get(stack.peek()).getCount() < infoArr.get(i).getCount()) {
+                result[stack.pop()] = infoArr.get(i).getNum();
+            }
+            stack.push(i);
+        }
+
+        while (!stack.isEmpty()) {
+            result[stack.pop()] = -1;
+        }
+
+        StringBuilder sb  = new StringBuilder();
+        for (int i = 0; i < n; i++) {
+            sb.append(result[i]).append(" ");
+        }
+
+        System.out.println(sb);
+    }
+}


### PR DESCRIPTION
## 풀이

### 풀이에 대한 직관적인 설명

스택에 새로 들어오는 수가 top에 존재하는 수보다 크면 그 수는 오등큰수가 된다. (오동재 오동큰수 아니고 **오등큰수** ㅎㅎ)

### 풀이 도출 과정

17298 오큰수랑 매우 비슷한 문제인데 배열 처리와 비교값이 등장 빈도라는 점이 추가된 문제이다.
* 스택에 새롭게 들어오는 수가 top에 존재하는 수보다 작거나 없어질 때까지 pop을 반복해서 배열에 오등큰수를 저장
* Node 클래스를 따로 만들어서 비교는 카운트로, 저장은 숫자로 할 수 있도록 구현

## 복잡도

<!-- 푼 알고리즘에 대한 시간복잡도 작성 -->

* 시간복잡도: O(n)

<!-- 위와 같이 복잡도를 산정하게 된 이유 --> 

구조는 이중 반복문이지만 스택에 삽입되고 삭제되는 연산이 숫자당 한번씩만 수행되므로 O(n)

## 채점 결과

<!-- 문제 푼 결과 캡처 -->

<img width="856" alt="Screenshot 2024-10-03 at 4 31 33 PM" src="https://github.com/user-attachments/assets/93da39f6-75db-48be-9803-02bc668dcfc2">