### PR TITLE
강두오 21일차 문제 풀이

### DIFF
--- a/duoh/BOJ/src/java_23254/Main.java
+++ b/duoh/BOJ/src/java_23254/Main.java
@@ -14,25 +14,25 @@ public class Main {
         StringTokenizer st = new StringTokenizer(br.readLine());
         int N = Integer.parseInt(st.nextToken()) * 24;
         int M = Integer.parseInt(st.nextToken());
-        int[][] students = new int[M][2];
+        int[][] subjects = new int[M][2];
 
         StringTokenizer st1 = new StringTokenizer(br.readLine());
         StringTokenizer st2 = new StringTokenizer(br.readLine());
         for (int i = 0; i < M; i++) {
-            students[i][0] = Integer.parseInt(st1.nextToken());
-            students[i][1] = Integer.parseInt(st2.nextToken());
+            subjects[i][0] = Integer.parseInt(st1.nextToken());
+            subjects[i][1] = Integer.parseInt(st2.nextToken());
         }
 
         PriorityQueue<int[]> pq = new PriorityQueue<>((o1, o2) -> o2[1] - o1[1]);
         for (int i = 0; i < M; i++) {
-            pq.offer(new int[]{students[i][0], students[i][1]});
+            pq.offer(new int[]{subjects[i][0], subjects[i][1]});
         }
 
         int total = 0;
         while (N > 0 && !pq.isEmpty()) {
-            int[] student = pq.poll();
-            int score = student[0];
-            int growth = student[1];
+            int[] subject = pq.poll();
+            int score = subject[0];
+            int growth = subject[1];
 
             int hours = Math.min(N, (MAX - score) / growth);
             score += growth * hours;

--- a/duoh/BOJ/src/java_25918/Main.java
+++ b/duoh/BOJ/src/java_25918/Main.java
@@ -1,0 +1,31 @@
+package java_25918;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayDeque;
+import java.util.Deque;
+
+public class Main {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        int N = Integer.parseInt(br.readLine());
+        char[] S = br.readLine().toCharArray();
+        Deque<Character> stack = new ArrayDeque<>();
+        int days = 0;
+
+        for (char s : S) {
+            if (!stack.isEmpty() && !stack.peek().equals(s)) {
+                stack.pop();
+            } else {
+                stack.push(s);
+            }
+
+            days = Math.max(days, stack.size());
+        }
+
+        System.out.println(!stack.isEmpty() ? -1 : days);
+        br.close();
+    }
+}


### PR DESCRIPTION
## 풀이

### 풀이에 대한 직관적인 설명

- 괄호 쌍을 매칭해서 제거하는데 최소 며칠이 걸리는지 계산하는 문제이다.


### 풀이 도출 과정

핵심은 처리되지 않은 괄호의 수에 따라 `days`를 갱신하는 것이다.

- 문자열 배열 S를 순회하면서 스택의 `top`과 현재 문자가 다르면 `pop`, 같으면 `push`
- `days`와 스택의 크기(처리되지 않은 괄호의 수)를 비교하여 큰 값으로 갱신
- 모두 처리하고 스택이 비어있으면 `days`, 아니라면 `-1` 출력

## 복잡도

* 시간복잡도: O(n)

문자열 길이 N에 대해 스택 연산을 한 번씩 처리함


## 채점 결과
<img width="938" alt="스크린샷 2024-10-07 오전 9 05 26" src="https://github.com/user-attachments/assets/2a7b0ed5-a895-4ec4-b893-3cae3209519b">