### PR TITLE
강두오 22일차 문제 풀이

### DIFF
--- a/duoh/BOJ/src/java_3015/Main.java
+++ b/duoh/BOJ/src/java_3015/Main.java
@@ -1,0 +1,38 @@
+package java_3015;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayDeque;
+import java.util.Deque;
+
+public class Main {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        Deque<int[]> stack = new ArrayDeque<>();
+        long answer = 0;
+
+        int N = Integer.parseInt(br.readLine());
+        while (N-- > 0) {
+            int height = Integer.parseInt(br.readLine());
+            int count = 1;
+
+            while (!stack.isEmpty() && stack.peek()[0] <= height) {
+                answer += stack.peek()[1];
+                if (stack.peek()[0] == height) {
+                    count += stack.peek()[1];
+                }
+                stack.pop();
+            }
+            stack.push(new int[]{height, count});
+
+            if (stack.size() > 1) {
+                answer++;
+            }
+        }
+
+        System.out.println(answer);
+        br.close();
+    }
+}


### PR DESCRIPTION
## 풀이

### 풀이에 대한 직관적인 설명

- 현재 사람의 키보다 작은 사람들을 스택에서 제거하면서, 서로 볼 수 있는 쌍의 수를 구하는 문제이다.

### 풀이 도출 과정

핵심은 같은 키를 가진 사람들을 하나로 묶어 처리하는 것이다.

- 스택에는 **키**와 **같은 키인 사람 수**를 저장함
- 현재 사람의 키보다 작은 사람은 스택에서 제거하고, 쌍의 수를 `answer`에 더함
- 같은 키는 묶어서 중복 카운팅을 방지함
- 스택에 두 명 이상 남아있으면, 서로 볼 수 있으므로 `answer++`
- 1 <= `N` <= 500,000 이므로, `long`형을 사용해야됨

> 이 문제를 풀고, '모노톤 스택'이라는 개념을 처음 알게되어 찾아봤다.
> - [모노톤 스택, 큐,덱에 관하여](https://velog.io/@junr_65535/%EB%AA%A8%EB%85%B8%ED%86%A4-%EC%8A%A4%ED%83%9D-%ED%81%90%EB%8D%B1%EC%97%90-%EA%B4%80%ED%95%98%EC%97%AC)


## 복잡도

* 시간복잡도: O(n)

각 사람에 대해 `push`, `pop` 연산


## 채점 결과
<img width="938" alt="스크린샷 2024-10-08 오후 8 50 39" src="https://github.com/user-attachments/assets/3f1b3b94-61e2-4c41-a07e-98d6d7e2514d">
