### PR TITLE
오동재 23일차 문제 풀이

### DIFF
--- a/dongjae/BOJ/src/java_6198/Main.java
+++ b/dongjae/BOJ/src/java_6198/Main.java
@@ -1,0 +1,33 @@
+package java_6198;
+
+import java.util.*;
+import java.io.*;
+
+public class Main {
+    public static int n;
+    public static long[] array;
+    public static Stack<Integer> stack = new Stack<>();
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        n = Integer.parseInt(br.readLine());
+
+        array = new long[n];
+
+        for (int i = 0; i < n; i++) {
+            array[i] = Long.parseLong(br.readLine());
+        }
+
+        long count = 0;
+        for (int i = 0; i < n; i++) {
+            long now = array[i];
+            while (!stack.isEmpty() && array[stack.peek()] <= now) {
+                stack.pop();
+            }
+            count += stack.size();
+            stack.push(i);
+        }
+
+        System.out.println(count);
+    }
+}


### PR DESCRIPTION
## 풀이

### 풀이에 대한 직관적인 설명

관점을 내가 볼 수 있는 빌딩의 수의 합이 아니라, 나를 볼 수 있는 빌딩의 수의 합으로 생각하면 쉽다.

### 풀이 도출 과정

배열을 순회하며 빌딩의 인덱스를 스택에 삽입하되, 삽입하려는 빌딩보다 높이가 같거나 작은 빌딩은 pop한다. 이렇게 자기 자신보다 높이가 같거나 작은 빌딩을 모두 제거하면 자신을 볼 수 있는 빌딩만 남게되고 이를 모두 더하면 된다.

## 복잡도

<!-- 푼 알고리즘에 대한 시간복잡도 작성 -->

* 시간복잡도: O(n)

<!-- 위와 같이 복잡도를 산정하게 된 이유 --> 

구조는 이중 반복문이지만 스택에 삽입되고 삭제되는 연산이 한 번씩만 이루어지므로 전체 시간복잡도는 O(n)

## 채점 결과

<!-- 문제 푼 결과 캡처 -->
<img width="859" alt="Screenshot 2024-10-09 at 7 11 15 PM" src="https://github.com/user-attachments/assets/c381830f-e8b7-480c-ab63-7e86d32fb68e">