### PR TITLE
강두오 24일차 문제 풀이

### DIFF
--- a/duoh/BOJ/src/java_9466/Main.java
+++ b/duoh/BOJ/src/java_9466/Main.java
@@ -1,0 +1,58 @@
+package java_9466;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.*;
+
+public class Main {
+    private static int[] arr;
+    private static boolean[] visited, finished;
+    private static int count;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        StringBuilder sb = new StringBuilder();
+        int T = Integer.parseInt(br.readLine());
+
+        while (T-- > 0) {
+            int n = Integer.parseInt(br.readLine());
+            StringTokenizer st = new StringTokenizer(br.readLine());
+
+            arr = new int[n + 1];
+            visited = new boolean[n + 1];
+            finished = new boolean[n + 1];
+            count = 0;
+
+            for (int i = 1; i <= n; i++) {
+                arr[i] = Integer.parseInt(st.nextToken());
+            }
+
+            for (int i = 1; i <= n; i++) {
+                if (!visited[i]) {
+                    dfs(i);
+                }
+            }
+            sb.append(n - count).append('\n');
+        }
+
+        System.out.println(sb);
+        br.close();
+    }
+
+    private static void dfs(int start) {
+        visited[start] = true;
+        int next = arr[start];
+
+        if (!visited[next]) {
+            dfs(next);
+        } else if (!finished[next]) {
+            count++;
+            for (int i = next; i != start; i = arr[i]) {
+                count++;
+            }
+        }
+        finished[start] = true;
+    }
+}


### PR DESCRIPTION
## 풀이

### 풀이에 대한 직관적인 설명

- dfs + 싸이클
- 싸이클을 찾고, 싸이클에 속하지 않는 노드의 개수를 구하는 문제이다.

> 위상정렬로도 풀리는 문제

### 풀이 도출 과정

핵심은 싸이클이 탐지되면 재순회하면서 카운트하는 것이다.

- 각 노드는 다음 노드를 가리키는 구조임
- `visited` 배열은 각 노드의 방문 여부 체크, `finished` 배열은 처리가 끝난 노드 체크
- 싸이클이 탐지되면 재순회하면서 카운트함
- 싸이클에 속하지 않은 노드의 수는 `n - count`


## 복잡도

* 시간복잡도: O(n)

모든 노드는 한 번씩만 방문됨


## 채점 결과
<img width="940" alt="스크린샷 2024-10-10 오후 10 15 36" src="https://github.com/user-attachments/assets/d3587768-c7c9-4da2-8161-f3049a5e0e77">