### PR TITLE
오동재 24일차 문제 풀이

### DIFF
--- a/dongjae/BOJ/src/java_10026/Main.java
+++ b/dongjae/BOJ/src/java_10026/Main.java
@@ -1,0 +1,72 @@
+package java_10026;
+
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    public static int n;
+    public static char[][] map;
+    public static boolean[][] visited;
+    public static int[] dx = {-1, 0, 1, 0};
+    public static int[] dy = {0, 1, 0, -1};
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        n = Integer.parseInt(br.readLine());
+
+        map = new char[n][n];
+        visited = new boolean[n][n];
+
+        for (int i = 0; i < n; i++) {
+            String str = br.readLine();
+            for (int j = 0; j < n; j++) {
+                map[i][j] = str.charAt(j);
+            }
+        }
+
+        StringBuilder sb = new StringBuilder();
+
+        // 정상인의 눈
+        sb.append(checkArea()).append(" ");
+
+        // 색맹의 눈
+        for (int i = 0; i < n; i++) {
+            for (int j = 0; j < n; j++) {
+                if (map[i][j] == 'R') map[i][j] = 'G';
+            }
+        }
+        sb.append(checkArea());
+
+        System.out.println(sb);
+    }
+
+    public static int checkArea() {
+        int count = 0;
+        for (int i = 0; i < n; i++) {
+            for (int j = 0; j < n; j++) {
+                if (!visited[i][j]) {
+                    dfs(i, j);
+                    count++;
+                }
+            }
+        }
+
+        visited = new boolean[n][n];
+        return count;
+    }
+
+    public static void dfs(int x, int y) {
+        visited[x][y] = true;
+        char now = map[x][y];
+        for (int i = 0; i < 4; i++) {
+            int nx = x + dx[i];
+            int ny = y + dy[i];
+
+            if (nx >= 0 && ny >= 0 && nx < n && ny < n) {
+                if (!visited[nx][ny] && map[nx][ny] == now) {
+                    dfs(nx, ny);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 풀이

### 풀이에 대한 직관적인 설명

dfs 또는 bfs를 이용하여 영역을 체크한다.

### 풀이 도출 과정

가물가물해진 그래프 탐색 개념, 그중에서도 dfs를 복습하기 위해 dfs로 풀이하였다. dfs는 스택 또는 재귀함수를 이용하여 풀이 가능한데 간결성의 이유로 주로 ps에서는 재귀함수로 풀이한다고 한다.

* 영역 정보를 저장한다.
* 방문 정보를 체크하며 색이 같은 인접 영역을 dfs를 통해 모두 방문 처리한다.
* 기존 영역의 탐색을 모두 마칠 때마다 count를 1씩 증가시킨다.

## 복잡도

<!-- 푼 알고리즘에 대한 시간복잡도 작성 -->

* 시간복잡도: O(n^2)

<!-- 위와 같이 복잡도를 산정하게 된 이유 --> 

모든 노드를 방문하는 연산이 대부분이자 가장 큰 복잡도이므로 O(n^2)

## 채점 결과

<!-- 문제 푼 결과 캡처 -->
<img width="858" alt="Screenshot 2024-10-11 at 4 14 45 PM" src="https://github.com/user-attachments/assets/3823b4d2-a3c0-4f8f-8131-7d150275fabd">