### PR TITLE
강두오 25일차 문제 풀이

### DIFF
--- a/duoh/BOJ/src/java_2251/Main.java
+++ b/duoh/BOJ/src/java_2251/Main.java
@@ -1,0 +1,90 @@
+package java_2251;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.*;
+
+public class Main {
+    private static final int MAX = 200;
+    private static int A, B, C;
+    private static Set<Integer> list;
+    private static boolean[][][] visited;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        A = Integer.parseInt(st.nextToken());
+        B = Integer.parseInt(st.nextToken());
+        C = Integer.parseInt(st.nextToken());
+        list = new TreeSet<>();
+        visited = new boolean[MAX + 1][MAX + 1][MAX + 1];
+
+        bfs();
+        StringBuilder sb = new StringBuilder();
+        for (int li : list) {
+            sb.append(li).append(' ');
+        }
+
+        System.out.println(sb);
+        br.close();
+    }
+
+    private static void bfs() {
+        Deque<int[]> q = new ArrayDeque<>();
+        q.offer(new int[] {0, 0, C});
+
+        while (!q.isEmpty()) {
+            int[] cur = q.poll();
+            int curA = cur[0], curB = cur[1], curC = cur[2];
+
+            if (visited[curA][curB][curC]) continue;
+            visited[curA][curB][curC] = true;
+
+            if (curA == 0) list.add(curC);
+
+            // A -> B
+            if (curA + curB >= B) {
+                q.offer(new int[] {curA - (B - curB), B, curC});
+            } else {
+                q.offer(new int[] {0, curB + curA, curC});
+            }
+
+            // A -> C
+            if (curA + curC >= C) {
+                q.offer(new int[] {curA - (C - curC), curB, C});
+            } else {
+                q.offer(new int[] {0, curB, curC + curA});
+            }
+
+            // B -> A
+            if (curB + curA >= A) {
+                q.offer(new int[] {A, curB - (A - curA), curC});
+            } else {
+                q.offer(new int[] {curA + curB, 0, curC});
+            }
+
+            // B -> C
+            if (curB + curC >= C) {
+                q.offer(new int[] {curA, curB - (C - curC), C});
+            } else {
+                q.offer(new int[] {curA, 0, curB + curC});
+            }
+
+            // C -> A
+            if (curC + curA >= A) {
+                q.offer(new int[] {A, curB, curC - (A - curA)});
+            } else {
+                q.offer(new int[] {curC + curA, curB, 0});
+            }
+
+            // C -> B
+            if (curC + curB >= B) {
+                q.offer(new int[] {curA, B, curC - (B - curB)});
+            } else {
+                q.offer(new int[] {curA, curC + curB, 0});
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 풀이

### 풀이에 대한 직관적인 설명

- `A`, `B`, `C` 세 개의 물통이 있고, 각 물통에 담긴 물을 옮겨가며 가능한 모든 경우의 물의 양을 탐색하는 문제이다.
- 단, `A` 물통이 비어있을 때 `C` 물통에 남아있는 물의 양을 오름차순으로 출력해야된다.

### 풀이 도출 과정

bfs를 통해 구현했지만, 크기가 크지않아서 브루트포스로도 풀리는듯..?

- 물을 옮기는 방법은 `A -> B`, `A -> C`, `B -> A`, `B -> C`, `C -> A`, `C -> B` 총 6가지 경우의 수가 있다.
- 각 경우에 따라, 물이 넘치는 경우와 넘치지 않는 경우로 조건 처리하며 구현하면 된다.
- bfs 탐색하며 `A` 물통이 비어있을 경우 `list`에 추가
- 탐색이 끝나면, 오름차순으로 출력

## 복잡도

* 시간복잡도: O(201^3)

각 물통의 최대 부피는 200이고, bfs를 통해 각 상태를 한 번씩만 방문하므로 O(201^3)

## 채점 결과
<img width="939" alt="스크린샷 2024-10-12 오후 11 11 50" src="https://github.com/user-attachments/assets/3304d985-14b5-4f7a-9998-134535dd0c98">

> 풀 때는 분명 골드5였는데.. 풀고 기여했더니 골드4로 바뀌는 마법
> `List + 정렬` 과 `TreeSet`을 사용하여 풀이해봤는데, 그닥 차이는 없다
