### PR TITLE
강두오 26일차 문제 풀이

### DIFF
--- a/duoh/BOJ/src/java_1743/Main.java
+++ b/duoh/BOJ/src/java_1743/Main.java
@@ -1,0 +1,62 @@
+package java_1743;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class Main {
+    private static final int[] dx = {-1, 0, 1, 0};
+    private static final int[] dy = {0, 1, 0, -1};
+    private static boolean[][] map;
+    private static boolean[][] visited;
+    private static int N, M;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        N = Integer.parseInt(st.nextToken());
+        M = Integer.parseInt(st.nextToken());
+        int K = Integer.parseInt(st.nextToken());
+
+        map = new boolean[N][M];
+        visited = new boolean[N][M];
+
+        while (K-- > 0) {
+            st = new StringTokenizer(br.readLine());
+            int r = Integer.parseInt(st.nextToken());
+            int c = Integer.parseInt(st.nextToken());
+            map[--r][--c] = true;
+        }
+
+        int ans = 0;
+        for (int i = 0; i < N; i++) {
+            for (int j = 0; j < M; j++) {
+                if (!visited[i][j] && map[i][j]) {
+                    ans = Math.max(ans, dfs(i, j));
+                }
+            }
+        }
+
+        System.out.println(ans);
+        br.close();
+    }
+
+    private static int dfs(int x, int y) {
+        int count = 1;
+        visited[x][y] = true;
+
+        for (int i = 0; i < 4; i++) {
+            int cx = x + dx[i];
+            int cy = y + dy[i];
+
+            if (cx >= 0 && cy >= 0 && cx < N && cy < M) {
+                if (!visited[cx][cy] && map[cx][cy]) {
+                    count += dfs(cx, cy);
+                }
+            }
+        }
+        return count;
+    }
+}


### PR DESCRIPTION
## 풀이

### 풀이에 대한 직관적인 설명

- `N * M` 크기의 배열에서 서로 인접한 음식물 덩어리를 찾고, 그중 가장 큰 덩어리의 크기를 구하는 문제이다.

### 풀이 도출 과정

- 상하좌우 배열을 정의하고, 음식물이 있는 칸은 `true`로 설정
- 각 칸을 순회하면서 방문하지 않았고, 음식물이 존재하는 칸에서 dfs 탐색
- dfs 탐색을 통해 인접한 음식물 덩어리를 카운트하고, 이를 반환하여 `ans` 값 갱신

## 복잡도

* 시간복잡도: O(N * M)

각 칸을  한 번씩 탐색하면서 dfs로 인접한 덩어리를 찾으므로, 탐색 범위는 N * M

## 채점 결과
<img width="939" alt="스크린샷 2024-10-14 오후 5 04 44" src="https://github.com/user-attachments/assets/57baa6d6-91d8-42b9-97a9-4e0f8d8d8364">