### PR TITLE
강두오 27일차 문제 풀이

### DIFF
--- a/duoh/BOJ/src/java_1240/Main.java
+++ b/duoh/BOJ/src/java_1240/Main.java
@@ -1,0 +1,60 @@
+package java_1240;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.StringTokenizer;
+
+public class Main {
+    private static List<int[]>[] graph;
+    private static boolean[] visited;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        int N = Integer.parseInt(st.nextToken());
+        int M = Integer.parseInt(st.nextToken());
+        graph = new ArrayList[N + 1];
+
+        for (int i = 1; i <= N; i++) {
+            graph[i] = new ArrayList<>();
+        }
+
+        for (int i = 0; i < N - 1; i++) {
+            st = new StringTokenizer(br.readLine());
+            int u = Integer.parseInt(st.nextToken());
+            int v = Integer.parseInt(st.nextToken());
+            int w = Integer.parseInt(st.nextToken());
+            graph[u].add(new int[] {v, w});
+            graph[v].add(new int[] {u, w});
+        }
+
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < M; i++) {
+            visited = new boolean[N + 1];
+            st = new StringTokenizer(br.readLine());
+            int u = Integer.parseInt(st.nextToken());
+            int v = Integer.parseInt(st.nextToken());
+            sb.append(dfs(u, v)).append('\n');
+        }
+
+        System.out.println(sb);
+        br.close();
+    }
+
+    private static int dfs(int start, int end) {
+        if (start == end) return 0;
+        visited[start] = true;
+
+        for (int[] nxt : graph[start]) {
+            if (!visited[nxt[0]]) {
+                int dist = dfs(nxt[0], end);
+                if (dist >= 0) return dist + nxt[1];
+            }
+        }
+        return -1;
+    }
+}


### PR DESCRIPTION
### ## 풀이

### 풀이에 대한 직관적인 설명

- 두 노드 사이의 거리를 구하는 문제이다.
- bfs, dfs, lca 등 다양한 풀이 가능

### 풀이 도출 과정

- 인접 리스트로 그래프를 구성하고, dfs를 통해 두 노드 간의 거리를 계산


## 복잡도

* 시간복잡도: O(N * M)

dfs로 각각에 대하여 모든 노드를 탐색할 수 있으므로, O(N * M)

## 채점 결과
<img width="939" alt="스크린샷 2024-10-15 오후 2 27 16" src="https://github.com/user-attachments/assets/d02e6a35-149c-48d7-b975-6d6180706de1">

 bfs와 dfs로 풀이했는데, lca도 연습해봐야겠다..