### PR TITLE
오동재 28일차 문제 풀이

### DIFF
--- a/dongjae/BOJ/src/java_4963/Main.java
+++ b/dongjae/BOJ/src/java_4963/Main.java
@@ -1,0 +1,65 @@
+package java_4963;
+
+import java.util.*;
+import java.io.*;
+
+public class Main {
+    public static int w = -1;
+    public static int h = -1;
+    public static int[][] map;
+    public static boolean[][] visited;
+    public static int[] dx = {-1, 0, 1, 0, -1, -1, 1, 1};
+    public static int[] dy = {0, -1, 0, 1, -1, 1, -1, 1};
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringBuilder sb = new StringBuilder();
+        StringTokenizer st;
+        while (true) {
+            st = new StringTokenizer(br.readLine());
+            w = Integer.parseInt(st.nextToken());
+            h = Integer.parseInt(st.nextToken());
+            if (w == 0 && h == 0) {
+                break;
+            }
+            map = new int[h][w];
+            visited = new boolean[h][w];
+            for (int i = 0; i < h; i++) {
+                st = new StringTokenizer(br.readLine());
+                for (int j = 0; j < w; j++) {
+                    map[i][j] = Integer.parseInt(st.nextToken());
+                }
+            }
+            sb.append(count()).append("\n");
+        }
+        System.out.println(sb);
+    }
+
+    public static int count() {
+        int count = 0;
+        for (int i = 0; i < h; i++) {
+            for (int j = 0; j < w; j++) {
+                if (!visited[i][j] && map[i][j] == 1) {
+                    dfs(i, j);
+                    count++;
+                }
+            }
+        }
+        return count;
+    }
+
+    public static void dfs(int x, int y) {
+        visited[x][y] = true;
+        int now = map[x][y];
+        for (int i = 0; i < 8; i++) {
+            int nx = x + dx[i];
+            int ny = y + dy[i];
+
+            if (nx >= 0 && ny >= 0 && nx < h && ny < w) {
+                if (!visited[nx][ny] && map[nx][ny] == now) {
+                    dfs(nx, ny);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 풀이

### 풀이에 대한 직관적인 설명

간단한 탐색 문제인데 자잘한 실수들이 발목을 잡았다. DFS로 풀이하였고, 섬을 구할 때마다, 즉 dfs가 탐색을 종료할 때마다 count 변수에 1을 더해준다.

### 풀이 도출 과정

* 보통 입력을 받을 수를 먼저 제공해주는 편인데 해당 문제는 입력이 끝내는 종료 입력문을 따로 제시하고 있다. 따라서 while 문으로 계속 입력을 받다가 0 0이 입력되면 반복문으로 탈출한다.
* 내 실수는 w와 h를 헷갈려서 반대로 적용한 부분들이 많았다.

## 복잡도

<!-- 푼 알고리즘에 대한 시간복잡도 작성 -->

* 시간복잡도: O(w * h) = O(n^2)

<!-- 위와 같이 복잡도를 산정하게 된 이유 --> 

2차원 배열의 완전탐색

## 채점 결과

<!-- 문제 푼 결과 캡처 -->
<img width="859" alt="Screenshot 2024-10-16 at 3 38 08 PM" src="https://github.com/user-attachments/assets/ffe889c7-b6d2-4502-a4ef-68be8d9f2d1c">