### PR TITLE
강두오 28일차 문제 풀이

### DIFF
--- a/duoh/BOJ/src/java_12886/Main.java
+++ b/duoh/BOJ/src/java_12886/Main.java
@@ -1,0 +1,72 @@
+package java_12886;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.StringTokenizer;
+
+public class Main {
+    private static int A, B, C;
+    private static boolean[][] visited;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        A = Integer.parseInt(st.nextToken());
+        B = Integer.parseInt(st.nextToken());
+        C = Integer.parseInt(st.nextToken());
+
+        if ((A + B + C) % 3 != 0) {
+            System.out.println(0);
+            return;
+        }
+
+        visited = new boolean[1501][1501];
+        System.out.println(bfs() ? 1 : 0);
+        br.close();
+    }
+
+    private static boolean bfs() {
+        Deque<int[]> q = new ArrayDeque<>();
+        q.offer(new int[]{A, B, C});
+        visited[A][B] = true;
+
+        while (!q.isEmpty()) {
+            int[] cur = q.poll();
+            int a = cur[0], b = cur[1], c = cur[2];
+
+            if (a == b && b == c) return true;
+
+            // A와 B
+            if (a < b && !visited[a + a][b - a]) {
+                q.offer(new int[]{a + a, b - a, c});
+                visited[a + a][b - a] = true;
+            } else if (a > b && !visited[b + b][a - b]) {
+                q.offer(new int[]{a - b, b + b, c});
+                visited[b + b][a - b] = true;
+            }
+
+            // A와 C
+            if (a < c && !visited[a + a][c - a]) {
+                q.offer(new int[]{a + a, b, c - a});
+                visited[a + a][c - a] = true;
+            } else if (a > c && !visited[c + c][a - c]) {
+                q.offer(new int[]{a - c, b, c + c});
+                visited[c + c][a - c] = true;
+            }
+
+            // B와 C
+            if (b < c && !visited[b + b][c - b]) {
+                q.offer(new int[]{a, b + b, c - b});
+                visited[b + b][c - b] = true;
+            } else if (b > c && !visited[c + c][b - c]) {
+                q.offer(new int[]{a, b - c, c + c});
+                visited[c + c][b - c] = true;
+            }
+        }
+        return false;
+    }
+}


### PR DESCRIPTION
## 풀이

### 풀이에 대한 직관적인 설명

- 세 개의 돌 그룹 `A`, `B`, `C`의 돌 개수를 모두 같게 만들 수 있는지 판별하는 문제이다.
- 크기가 같지 않은 두 그룹을 고른다. 작은 쪽 `X`는 `X + X`개로, 큰 쪽 `Y`는 `Y - X`개로 만든다.
- bfs를 통해 가능한 모든 상태 탐색

### 풀이 도출 과정

- `A + B + C`의 합이 3으로 나누어 떨어지지 않으면 모두 같게 만들 수 없다.
- bfs를 통해 각 상태를 탐색, 방문 상태는 `visited` 2차원 배열로 관리함
- 두 그룹의 개수를 알면 나머지 그룹의 개수는 자동으로 결정되므로, 2차원 배열로 풀이 가능함 (3차원 배열은 메모리 초과)

> 총 돌의 갯수가 일정하다는 사실을 눈치 못채서 삽질을 많이 했다..

## 복잡도

* 시간복잡도: O(n^2)

돌의 개수는 최대 1500이므로, 1500 * 1500개의 상태를 bfs 탐색 

## 채점 결과
<img width="939" alt="스크린샷 2024-10-16 오후 7 20 59" src="https://github.com/user-attachments/assets/0d750ed2-5dca-41f2-952f-cfd29048c38f">