### PR TITLE
강두오 30일차 문제 풀이

### DIFF
--- a/duoh/BOJ/src/java_16964/Main.java
+++ b/duoh/BOJ/src/java_16964/Main.java
@@ -1,0 +1,66 @@
+package java_16964;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.*;
+
+public class Main {
+    private static List<Integer>[] graph;
+    private static boolean[] visited;
+    private static int[] order;
+    private static int idx = 1;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        int N = Integer.parseInt(br.readLine());
+        graph = new ArrayList[N + 1];
+
+        for (int i = 1; i <= N; i++) {
+            graph[i] = new ArrayList<>();
+        }
+
+        visited = new boolean[N + 1];
+        StringTokenizer st;
+
+        for (int i = 0; i < N - 1; i++) {
+            st = new StringTokenizer(br.readLine());
+            int u = Integer.parseInt(st.nextToken());
+            int v = Integer.parseInt(st.nextToken());
+            graph[u].add(v);
+            graph[v].add(u);
+        }
+
+        order = new int[N];
+        st = new StringTokenizer(br.readLine());
+
+        for (int i = 0; i < N; i++) {
+            order[i] = Integer.parseInt(st.nextToken());
+        }
+
+        System.out.println(order[0] == 1 && dfs(1) ? 1 : 0);
+        br.close();
+    }
+
+    private static boolean dfs(int x) {
+        visited[x] = true;
+        Set<Integer> set = new HashSet<>();
+
+        for (int y : graph[x]) {
+            if (!visited[y]) {
+                set.add(y);
+            }
+        }
+
+        for (int i = 0; i < set.size(); i++) {
+            if (!set.contains(order[idx])) {
+                return false;
+            }
+            if (!dfs(order[idx++])) {
+                return false;
+            }
+        }
+        return true;
+    }
+}


### PR DESCRIPTION
## 풀이

### 풀이에 대한 직관적인 설명

- 주어진 트리에서 dfs를 통해 노드 방문 순서가 `order` 배열과 일치할 수 있는지 확인하는 문제이다.
- 단, 시작 정점은 1여야 한다.

> 이번엔 dfs를 제대로 이해하고 있는지 확인하는 문제..ㅎ

### 풀이 도출 과정

- `order[0] == 1`인 경우에만 dfs 탐색함
- 방문하지 않은 자식 노드를 `set` 에 추가하고, 그 자식들이 `order` 배열에 나온 순서대로 존재하는지 확인
- 일치하지 않으면 `false`, 탐색이 끝까지 완료되면 `true`

## 복잡도

* 시간복잡도: O(n)

모든 노드를 한 번씩만 방문함

## 채점 결과
<img width="939" alt="스크린샷 2024-10-18 오후 7 40 24" src="https://github.com/user-attachments/assets/3bd83cae-dffa-4c09-bae4-d583f4541ba7">

> `Set` 사용안하고 풀어보려 했는데, 73퍼에서 시간 초과남..ㅎ;;