### PR TITLE
강두오 31일차 문제 풀이

### DIFF
--- a/duoh/BOJ/src/java_14627/Main.java
+++ b/duoh/BOJ/src/java_14627/Main.java
@@ -1,0 +1,46 @@
+package java_14627;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class Main {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        int S = Integer.parseInt(st.nextToken());
+        int C = Integer.parseInt(st.nextToken());
+
+        int[] arr = new int[S];
+        long total = 0L;
+        int max = 0;
+
+        for (int i = 0; i < S; i++) {
+            arr[i] = Integer.parseInt(br.readLine());
+            total += arr[i];
+            max = Math.max(max, arr[i]);
+        }
+
+        int left = 1, right = max, best = 0;
+        while (left <= right) {
+            int mid = (left + right) / 2;
+            int count = 0;
+
+            for (int a : arr) {
+                count += a / mid;
+            }
+
+            if (count >= C) {
+                best = mid;
+                left = mid + 1;
+            } else {
+                right = mid - 1;
+            }
+        }
+
+        System.out.println(total - (long) best * C);
+        br.close();
+    }
+}


### PR DESCRIPTION
## 풀이

### 풀이에 대한 직관적인 설명

- 주어진 파를 일정한 길이로 잘라서 주문받은 파닭을 만들고, 남는 파의 양을 구하는 문제이다.

### 풀이 도출 과정

- `left`는 1, `right`는 가장 긴 파의 길이로 설정한 후, 이분 탐색
- `mid` 값으로 잘랐을 때 만들 수 있는 파닭의 수를 계산함
- 주문받은 파닭의 수 이상이면 `left` 증가, 아니라면 `right` 감소 후 다시 시도
- 파닭을 만들고 남는 파의 양은 `total - (long) best * C`로 계산함
- 파의 길이 범위가 `1 <= L <= 1,000,000,000` 이므로, `long` 타입을 사용해야 함

## 복잡도

* 시간복잡도: O(S * log(max))

이분 탐색의 시간복잡도는 log(max), 각 탐색에서 파 배열을 순회하므로 O(S * log(max))

## 채점 결과
<img width="939" alt="스크린샷 2024-10-19 오후 6 20 35" src="https://github.com/user-attachments/assets/74d63d97-71ee-4eb0-b76b-023e314c75c8">