### PR TITLE
강두오 32일차 문제 풀이

### DIFF
--- a/duoh/BOJ/src/java_17951/Main.java
+++ b/duoh/BOJ/src/java_17951/Main.java
@@ -1,0 +1,48 @@
+package java_17951;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class Main {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        int N = Integer.parseInt(st.nextToken());
+        int K = Integer.parseInt(st.nextToken());
+
+        st = new StringTokenizer(br.readLine());
+        int[] X = new int[N];
+        int left = Integer.MAX_VALUE, right = 0;
+
+        for (int i = 0; i < N; i++) {
+            X[i] = Integer.parseInt(st.nextToken());
+            left = Math.min(left, X[i]);
+            right += X[i];
+        }
+
+        while (left <= right) {
+            int mid = (left + right) / 2;
+            int sum = 0, count = 0;
+
+            for (int x : X) {
+                sum += x;
+                if (sum >= mid) {
+                    sum = 0;
+                    count++;
+                }
+            }
+
+            if (count >= K) {
+                left = mid + 1;
+            } else {
+                right = mid - 1;
+            }
+        }
+
+        System.out.println(right);
+        br.close();
+    }
+}


### PR DESCRIPTION
## 풀이

### 풀이에 대한 직관적인 설명

- 주어진 배열 `X`를 `K`개의 그룹으로 나누어, 각 그룹의 합 중 최솟값을 최대화하는 문제이다.

### 풀이 도출 과정

- `left`는 배열의 최소값, `right`는 배열의 총합으로 설정한 후, 이분 탐색
- 배열을 순회하며 합이 `mid` 이상일 때 그룹을 나누고, `count++`
- 그룹의 수가 `K`개 이상이면 `left` 증가, 아니라면 `right` 감소 후 다시 시도
- 탐색 종료 후, `right` 출력

## 복잡도

* 시간복잡도: O(N log M)

`N`은 배열의 크기, `M`은 배열의 총합

## 채점 결과
<img width="939" alt="스크린샷 2024-10-20 오후 5 23 40" src="https://github.com/user-attachments/assets/55f37e4a-0496-48e3-b5c2-7087fd83992f">