### PR TITLE
강두오 33일차 문제 풀이

### DIFF
--- a/duoh/BOJ/src/java_17245/Main.java
+++ b/duoh/BOJ/src/java_17245/Main.java
@@ -1,0 +1,50 @@
+package java_17245;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class Main {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        int N = Integer.parseInt(br.readLine());
+        int[][] map = new int[N][N];
+
+        StringTokenizer st;
+        long total = 0;
+        int max = 0;
+
+        for (int i = 0; i < N; i++) {
+            st = new StringTokenizer(br.readLine());
+
+            for (int j = 0; j < N; j++) {
+                map[i][j] = Integer.parseInt(st.nextToken());
+                total += map[i][j];
+                max = Math.max(max, map[i][j]);
+            }
+        }
+
+        int left = 0, right = max;
+        while (left <= right) {
+            int mid = (left + right) / 2;
+            long count = 0;
+
+            for (int i = 0; i < N; i++) {
+                for (int j = 0; j < N; j++) {
+                    count += Math.min(mid, map[i][j]);
+                }
+            }
+
+            if (count * 2 >= total) {
+                right = mid - 1;
+            } else {
+                left = mid + 1;
+            }
+        }
+
+        System.out.println(left);
+        br.close();
+    }
+}


### PR DESCRIPTION
## 풀이

### 풀이에 대한 직관적인 설명

- 1분마다 차가운 공기가 컴퓨터 한 대의 높이만큼 방을 채운다.
- 서버실의 총 컴퓨터 중, 절반 이상이 켜지려면 몇 분이 필요한지 구하는 문제이다.

### 풀이 도출 과정

- `left`는 0, `right`는 배열의 최대값으로 설정한 후, 이분 탐색
- 배열을 순회하며 `mid` 이하의 컴퓨터 수를 카운트하고, 절반 이상인지 확인
- 절반 이상이면 `right` 감소, 아니라면 `left` 증가 후 다시 시도
- 탐색 종료 후, `left` 출력

> 한 칸에는 최대 `10,000,000대` 까지 쌓여있을 수 있으므로, `total` 과 `count`는 `long 타입`을 사용해야 함

## 복잡도

* 시간복잡도: O(n^2 log(max))

서버실은 `N * N` 칸이므로 배열 순회에 O(n^2), 이분 탐색에 `log(max)` 가 걸림

## 채점 결과
<img width="937" alt="스크린샷 2024-10-22 오후 8 21 45" src="https://github.com/user-attachments/assets/9f8d3422-5eee-4b9e-aa24-812ee78f3de2">