### PR TITLE
오동재 31일차 문제 풀이

### DIFF
--- a/dongjae/BOJ/src/java_1987/Main.java
+++ b/dongjae/BOJ/src/java_1987/Main.java
@@ -1,0 +1,50 @@
+package java_1987;
+
+import java.util.*;
+import java.io.*;
+
+public class Main {
+    public static int r, c;
+    public static char[][] board;
+    public static boolean[] visited;
+    public static int[] dx = {-1, 0, 1, 0};
+    public static int[] dy = {0, 1, 0, -1};
+    public static int max = Integer.MIN_VALUE;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        r = Integer.parseInt(st.nextToken());
+        c = Integer.parseInt(st.nextToken());
+
+        board = new char[r][c];
+        visited = new boolean[26];
+
+        for (int i = 0; i < r; i++) {
+            char[] charArr = br.readLine().toCharArray();
+            for (int j = 0; j < c; j++) {
+                board[i][j] = charArr[j];
+            }
+        }
+
+        dfs(0, 0, 1);
+
+        System.out.println(max);
+    }
+
+    public static void dfs(int x, int y, int step) {
+        visited[(int) board[x][y] - 'A'] = true;
+        max = Math.max(max, step);
+        for (int i = 0; i < 4; i++) {
+            int nx = x + dx[i];
+            int ny = y + dy[i];
+            if (nx >= 0 && ny >= 0 && nx < r && ny < c) {
+                if (!visited[(int) board[nx][ny] - 'A']) {
+                    dfs(nx, ny, step + 1);
+                }
+            }
+        }
+        visited[(int) board[x][y] - 'A'] = false;
+    }
+}


### PR DESCRIPTION
## 풀이

### 풀이에 대한 직관적인 설명

DFS + 백트래킹

### 풀이 도출 과정

백트래킹에 대한 개념이 부족해서 다시 찾아보면서 풀어보았다. 재귀함수 호출을 종료하면서 이전에 지나왔던 경로를 말끔히 정리하고 가는 로직이 필요하다. 그 부분을 신경써서 구현하면 나머지는 DFS랑 같은 풀이다.

## 복잡도

<!-- 푼 알고리즘에 대한 시간복잡도 작성 -->

* 시간복잡도: O(4^26) or O(4^(R*C))
* 굳이 n으로 표기하자면 O(2^n)이 된다. 다만 여기서 n은 52를 넘지 않는다.
* 4^26 = (2^2)^26 = 2^52

<!-- 위와 같이 복잡도를 산정하게 된 이유 -->

상하좌우 총 4번의 재귀 함수 호출이 알파벳 길이만큼 또는 보드 크기만큼 반복되기 때문에

## 채점 결과

<!-- 문제 푼 결과 캡처 -->
<img width="861" alt="Screenshot 2024-10-22 at 11 20 40 PM" src="https://github.com/user-attachments/assets/455516b8-0efb-4027-9b0e-d6f22d12c688">