### PR TITLE
김은혜 33일차 문제 풀이

### DIFF
--- a/gracekim/2583.py
+++ b/gracekim/2583.py
@@ -1,0 +1,46 @@
+# 2583 / 영역 구하기 / Silver 1
+
+from collections import deque
+import sys 
+input = sys.stdin.readline
+
+m, n, k = map(int, input().split())
+maps = [[1] * m for _ in range(n)]
+
+for _ in range(k):
+  x1, y1, x2, y2 = map(int, input().split())
+  for i in range(x1, x2):
+    for j in range(y1 ,y2):
+      maps[i][j] = 0
+      
+result = []
+q = deque()
+
+for x in range(n):
+  for y in range(m):
+    if maps[x][y] == 1:
+      ans = 0
+      q.append((x, y))
+      maps[x][y] = 0
+      
+      while q:
+        x_, y_ = q.popleft()
+        ans += 1
+        
+        dx = [0, 0, 1, -1]
+        dy = [1, -1, 0, 0]
+        
+        for l in range(4):
+          nx = x_ + dx[l]
+          ny = y_ + dy[l]
+          
+          if 0 <= nx < n and 0 <= ny < m:
+            if maps[nx][ny] == 1:
+              maps[nx][ny] = 0 
+              q.append((nx, ny))
+      
+      result.append(ans)
+
+print(len(result))
+result.sort()
+print(*result)


### PR DESCRIPTION
## 문제

[2583 / 영역 구하기](https://www.acmicpc.net/problem/2583)

## 풀이

### 풀이에 대한 직관적인 설명

- BFS를 통해 풀었습니다.

### 풀이 도출 과정

- 반복문을 통해 순회하면서 아직 탐색되지 않은 영역을 발견하면 그 영역에 BFS를 시작하여 모든 영역을 탐색합니다. 탐색한 영역의 개수와 영역의 크기를 오름차순으로 나열해서 출력합니다


## 복잡도

* 시간복잡도 O(m * n + k)
* BFS는 각 칸에 한 번씩 방문하므로 BFS 탐색 시간 복잡도 O(m*n)입니다. 도면의 크기에 따라 시간복잡도가 결정됩니다.

## 채점 결과

![image](https://github.com/user-attachments/assets/c1cd1548-8e6e-4dc4-8d0a-89da5b7df043)