### PR TITLE
오동재 32일차 문제 풀이

### DIFF
--- a/dongjae/BOJ/src/java_7562/Main.java
+++ b/dongjae/BOJ/src/java_7562/Main.java
@@ -1,0 +1,81 @@
+package java_7562;
+
+import java.util.*;
+import java.io.*;
+
+class Node {
+    private int x;
+    private int y;
+    private int step;
+
+    public Node(int x, int y, int step) {
+        this.x = x;
+        this.y = y;
+        this.step = step;
+    }
+
+    public int getX() {
+        return this.x;
+    }
+
+    public int getY() {
+        return this.y;
+    }
+
+    public int getStep() {
+        return this.step;
+    }
+}
+
+public class Main {
+    public static int t;
+    public static int n;
+    public static int[][] map;
+    public static int[] dx = {-1, -2, -1, -2, 1, 2, 1, 2};
+    public static int[] dy = {-2, -1, 2, 1, -2, -1, 2, 1};
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        t = Integer.parseInt(br.readLine());
+
+        StringBuilder sb = new StringBuilder();
+        StringTokenizer st;
+        for (int i = 0; i < t; i++) {
+            n = Integer.parseInt(br.readLine());
+            map = new int[n][n];
+            initMap();
+            st = new StringTokenizer(br.readLine());
+            bfs(new Node(Integer.parseInt(st.nextToken()), Integer.parseInt(st.nextToken()), 0));
+            st = new StringTokenizer(br.readLine());
+            sb.append(map[Integer.parseInt(st.nextToken())][Integer.parseInt(st.nextToken())]).append("\n");
+        }
+        System.out.println(sb);
+    }
+
+    public static void initMap() {
+        for (int i = 0; i < n; i++) {
+            for (int j = 0; j < n; j++) {
+                map[i][j] = -1;
+            }
+        }
+    }
+
+    public static void bfs(Node start) {
+        Queue<Node> q = new LinkedList<>();
+        q.offer(start);
+        map[start.getX()][start.getY()] = 0;
+        while (!q.isEmpty()) {
+            Node now = q.poll();
+            for (int i = 0; i < 8; i++) {
+                int nx = now.getX() + dx[i];
+                int ny = now.getY() + dy[i];
+                if (nx >= 0 && ny >= 0 && nx < n && ny < n) {
+                    if (map[nx][ny] == -1) {
+                        map[nx][ny] = now.getStep() + 1;
+                        q.offer(new Node(nx, ny, map[nx][ny]));
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 문제

[7562 나이트의 이동](https://www.acmicpc.net/problem/7562)
<!-- 문제 제목이랑 링크를 달아주세요 -->

## 풀이

### 풀이에 대한 직관적인 설명

BFS를 이용해서 이동 가능한 모든 칸의 최소 이동 횟수를 구한 후 찾고자 하는 칸의 이동 횟수를 출력한다.

### 풀이 도출 과정

특정 좌표만의 최소 이동 횟수를 따로 구하자니 해당 좌표만을 위한 로직을 구현하기보다 모든 루트를 구해놓고 해당하는 좌표의 최소 이동 거리만을 출력하는 편이 더 간단할 것 같았다. BFS를 이용해서 각 칸의 최소 이동 횟수를 기록했다.

## 복잡도

<!-- 푼 알고리즘에 대한 시간복잡도 작성 -->

* 시간복잡도: O(n^2)

<!-- 위와 같이 복잡도를 산정하게 된 이유 --> 

모든 칸을 BFS로 탐색하므로 O(n^2)

## 채점 결과

<!-- 문제 푼 결과 캡처 -->

<img width="859" alt="Screenshot 2024-10-23 at 3 28 22 PM" src="https://github.com/user-attachments/assets/7dcaf222-ba49-42b7-b272-bf72d6e2766b">