### PR TITLE
오동재 33일차 문제 풀이

### DIFF
--- a/dongjae/BOJ/src/java_1654/Main.java
+++ b/dongjae/BOJ/src/java_1654/Main.java
@@ -1,0 +1,46 @@
+package java_1654;
+
+import java.util.*;
+import java.io.*;
+
+public class Main {
+    public static int k, n;
+    public static long[] array;
+    public static long max = Long.MIN_VALUE;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        k = Integer.parseInt(st.nextToken());
+        n = Integer.parseInt(st.nextToken());
+
+        array = new long[k];
+        for (int i = 0; i < k; i++) {
+            array[i] = Long.parseLong(br.readLine());
+            max = Math.max(max, array[i]);
+        }
+
+        System.out.println(binarySearch(1, max));
+    }
+
+    public static long binarySearch(long start, long end) {
+        if (start > end) {
+            return end;
+        }
+        long mid = (start + end) / 2;
+        if (cut(mid) >= n) {
+            return binarySearch(mid + 1, end);
+        } else {
+            return binarySearch(start, mid - 1);
+        }
+    }
+
+    public static long cut(long length) {
+        long count = 0;
+        for (int i = 0; i < k; i++) {
+            count += (array[i] / length);
+        }
+        return count;
+    }
+}


### PR DESCRIPTION
## 문제

[1654 랜선 자르기](https://www.acmicpc.net/problem/1654)
<!-- 문제 제목이랑 링크를 달아주세요 -->

## 풀이

### 풀이에 대한 직관적인 설명

이분 탐색

### 풀이 도출 과정

아이디어 자체는 이분 탐색으로 범위만 조심을 한다면 쉽게 구현 가능하다. 다만 계속해서 오답 처리를 받아 원인을 찾다 한참을 헤매었는데, 이유는 int 타입의 범위 때문이었다. 2^32 - 1이면 int가 가질 수 있는 최대값이라 생각하여 당연히 모든 변수를 int로 선언했지만 문제는 이분 탐색에서 mid 값을 구할 때 `mid = (start + end) / 2` 부분에서 `start + end`를 계산할 때 해당 범위를 넘을 수도 있다는 점이었다. 이번 문제의 교훈은 헷갈릴 때는 그냥 long 타입으로 선언하자 이다.

## 복잡도

<!-- 푼 알고리즘에 대한 시간복잡도 작성 -->

* 시간복잡도: O(nlogn)

<!-- 위와 같이 복잡도를 산정하게 된 이유 --> 

이분 탐색을 할 때마다 나뉘어지는 랜선의 갯수를 구하는 연산이 n번 실행되므로 O(nlogn)

## 채점 결과

<!-- 문제 푼 결과 캡처 -->

<img width="859" alt="Screenshot 2024-10-23 at 4 49 55 PM" src="https://github.com/user-attachments/assets/1e95faa7-d4fa-4cbf-97ce-bfa85bcd7be4">
