### PR TITLE
오동재 41일차 문제 풀이

### DIFF
--- a/dongjae/BOJ/src/java_2559/Main.java
+++ b/dongjae/BOJ/src/java_2559/Main.java
@@ -1,0 +1,45 @@
+package java_2559;
+
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    public static int n, k;
+    public static int[] array;
+    public static long[] sumArray;
+    public static long max = Long.MIN_VALUE;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        n = Integer.parseInt(st.nextToken());
+        k = Integer.parseInt(st.nextToken());
+
+        array = new int[n+1];
+        sumArray = new long[n+1];
+
+        st = new StringTokenizer(br.readLine());
+
+        for (int i = 1; i <= n; i++) {
+            array[i] = Integer.parseInt(st.nextToken());
+            sumArray[i] = sumArray[i-1] + array[i];
+        }
+
+        findMax();
+
+        System.out.println(max);
+    }
+
+    public static void findMax() {
+        int start = 1;
+        int end = k;
+
+        while (end <= n) {
+            long now = sumArray[end] - sumArray[start-1];
+            max = Math.max(now, max);
+            start++;
+            end++;
+        }
+    }
+}


### PR DESCRIPTION
## 문제

[2559 수열](https://www.acmicpc.net/problem/2559)
<!-- 문제 제목이랑 링크를 달아주세요 -->

## 풀이

### 풀이에 대한 직관적인 설명

간단한 누적합 문제

### 풀이 도출 과정

누적합 배열을 구하고 k번 연속되는 수열의 합 중 가장 큰 것을 반복문을 통해 계산한다.

## 복잡도

<!-- 푼 알고리즘에 대한 시간복잡도 작성 -->

* 시간복잡도: O(n)

<!-- 위와 같이 복잡도를 산정하게 된 이유 -->

누적합 배열을 n번 만큼 순회하므로

## 채점 결과

<!-- 문제 푼 결과 캡처 -->

<img width="859" alt="Screenshot 2024-11-03 at 6 08 45 PM" src="https://github.com/user-attachments/assets/2d01098c-ea4d-4757-99d8-04364e0e3e34">
