### PR TITLE
강두오 39일차 문제 풀이

### DIFF
--- a/duoh/BOJ/src/java_25916/Main.java
+++ b/duoh/BOJ/src/java_25916/Main.java
@@ -1,0 +1,35 @@
+package java_25916;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class Main {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        int N = Integer.parseInt(st.nextToken());
+        int M = Integer.parseInt(st.nextToken());
+
+        st = new StringTokenizer(br.readLine());
+        int[] arr = new int[N];
+        for (int i = 0; i < N; i++) {
+            arr[i] = Integer.parseInt(st.nextToken());
+        }
+
+        int start = 0, sum = 0, max = 0;
+        for (int end = 0; end < N;) {
+            sum += arr[end++];
+
+            while (sum > M) {
+                sum -= arr[start++];
+            }
+            max = Math.max(max, sum);
+        }
+
+        System.out.println(max);
+        br.close();
+    }
+}


### PR DESCRIPTION
## 문제

[25916 싫은데요](https://www.acmicpc.net/problem/25916)

## 풀이

### 풀이에 대한 직관적인 설명

- 연속된 구멍들의 부피 합이 `M` 이하인 최대 크기를 구하는 문제이다.

### 풀이 도출 과정

- `end++` 하며 부피 합을 늘리고, 합이 `M`을 초과하면 `start++` 로 줄임

## 복잡도

* 시간복잡도: O(n)

배열을 한 번만 순회하므로 O(n)

## 채점 결과

<img width="940" alt="스크린샷 2024-11-04 오후 4 03 49" src="https://github.com/user-attachments/assets/e42f4507-eebc-4d09-aae8-82002af83688">
