### PR TITLE
오동재 44일차 문제 풀이

### DIFF
--- a/dongjae/BOJ/src/java_2579/Main.java
+++ b/dongjae/BOJ/src/java_2579/Main.java
@@ -1,0 +1,28 @@
+package java_2579;
+
+import java.io.*;
+
+public class Main {
+    public static int n;
+    public static int[] array = new int[301];
+    public static long[] d = new long[301];
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        n = Integer.parseInt(br.readLine());
+
+        for (int i = 0; i < n; i++) {
+            array[i] = Integer.parseInt(br.readLine());
+        }
+
+        d[0] = array[0];
+        d[1] = array[0] + array[1];
+        d[2] = Math.max(array[0], array[1]) + array[2];
+
+        for (int i = 3; i < n; i++) {
+            d[i] = Math.max(d[i-2], d[i-3] + array[i-1]) + array[i];
+        }
+
+        System.out.println(d[n-1]);
+    }
+}


### PR DESCRIPTION
## 문제

[2579 계단 오르기](https://www.acmicpc.net/problem/2579)
<!-- 문제 제목이랑 링크를 달아주세요 -->

## 풀이

### 풀이에 대한 직관적인 설명

DP 문제로 보텀업 방식을 이용하여 풀이하였다.

### 풀이 도출 과정

점화식으로 표현할 때 `f(n-1)`은 계산이 불가능하다. 왜냐하면 f(n)이 연속으로 하나씩 오른 3번째 칸이 될 수도 있기 때문이다.

따라서 점화식은 `f(n) = max(f(n-2), f(n-3) + step[n-1]) + step[n])`이 되어야 한다.

## 복잡도

<!-- 푼 알고리즘에 대한 시간복잡도 작성 -->

* 시간복잡도: O(n)

<!-- 위와 같이 복잡도를 산정하게 된 이유 --> 

DP를 적용한 점화식 풀이의 시간복잡도는 O(n)

## 채점 결과

<!-- 문제 푼 결과 캡처 -->

<img width="860" alt="Screenshot 2024-11-07 at 3 50 47 PM" src="https://github.com/user-attachments/assets/979d1652-2795-4875-aaf7-f49a5d091bed">
