### PR TITLE
오동재 45일차 문제 풀이

### DIFF
--- a/dongjae/BOJ/src/java_12865/Main.java
+++ b/dongjae/BOJ/src/java_12865/Main.java
@@ -1,0 +1,61 @@
+package java_12865;
+
+import java.io.*;
+import java.util.*;
+
+class Node {
+    private int weight;
+    private int value;
+
+    public Node(int weight, int value) {
+        this.weight = weight;
+        this.value = value;
+    }
+
+    public int getWeight() {
+        return this.weight;
+    }
+
+    public int getValue() {
+        return this.value;
+    }
+}
+
+public class Main {
+    public static int n, k;
+    public static int[][] dp;
+    public static ArrayList<Node> goods = new ArrayList<>();
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        n = Integer.parseInt(st.nextToken());
+        k = Integer.parseInt(st.nextToken());
+
+        goods.add(new Node(0, 0));
+        for (int i = 1; i <= n; i++) {
+            st = new StringTokenizer(br.readLine());
+            int w = Integer.parseInt(st.nextToken());
+            int v = Integer.parseInt(st.nextToken());
+            goods.add(new Node(w, v));
+        }
+
+        dp = new int[k+1][n+1];
+
+        for (int i = 1; i <= k; i++) {
+            for (int j = 1; j <= n; j++) {
+                if (goods.get(j).getWeight() > i) {
+                    dp[i][j] = dp[i][j-1];
+                } else {
+                    int r = i - goods.get(j).getWeight();
+                    dp[i][j] = Math.max(dp[i][j-1], dp[r][j-1] + goods.get(j).getValue());
+                }
+
+
+            }
+        }
+
+        System.out.println(dp[k][n]);
+    }
+}


### PR DESCRIPTION
## 문제

[12865 평범한 배낭](https://www.acmicpc.net/problem/12865)
<!-- 문제 제목이랑 링크를 달아주세요 -->

## 풀이

### 풀이에 대한 직관적인 설명

dp를 사용하는 배낭 문제

* 짐을 쪼갤 수 있는 배낭 문제 -> 그리디
* 짐을 쪼갤 수 없는 배낭 문제 -> dp

### 풀이 도출 과정

처음에는 그리디인 줄 알았는데 일단 카테고리는 dp라서... 헷갈려서 해설 검색함

일단 이차원 배열을 만들어서 (1부터 최대 무게까지) * (아이템 인덱스) 로 고정하고

무게별로 아이템 하나씩 추가하며 현재 상황에서 해당 아이템이 추가 가능한지 확인하고
* 가능하다면 `(현재 무게 - 현재 아이템 무게)에서의 최대 가치값 + 현재 아이템 가치값`을 구해서 저장하고
* 가능하지 않다면 이전 아이템까지 중에서 가능한 최대 가치값을 구함

## 복잡도

<!-- 푼 알고리즘에 대한 시간복잡도 작성 -->

* 시간복잡도: O(n*k)

<!-- 위와 같이 복잡도를 산정하게 된 이유 -->

dp니까...

## 채점 결과

<!-- 문제 푼 결과 캡처 -->

<img width="857" alt="Screenshot 2024-11-08 at 6 31 42 PM" src="https://github.com/user-attachments/assets/df9eb055-f070-408b-9233-6886567c7bfe">
