### PR TITLE
김신희 4?일차 문제 풀이

### DIFF
--- a/shinhee/BOJ/src/java_11726/Main.java
+++ b/shinhee/BOJ/src/java_11726/Main.java
@@ -1,0 +1,21 @@
+package BOJ.src.java_11726;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+public class Main {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int n = Integer.parseInt(br.readLine());
+
+        long[] dp = new long[n + 1];
+
+        dp[0] = 1;
+        dp[1] = 2;
+        for (int i = 2; i < n; i++) {
+            dp[i] = (dp[i - 1] + dp[i - 2]) % 10007;
+        }
+        System.out.println(dp[n - 1]);
+    }
+}


### PR DESCRIPTION
## 문제

[11726 2×n 타일링](https://www.acmicpc.net/problem/11726)
## 풀이

### 풀이에 대한 직관적인 설명
2×n 크기의 직사각형을 1×2, 2×1 타일로 채우는 방법의 수 구하기
### 풀이 도출 과정
메모이제이션할 배열  생성 후 초기값 설정,
점화식인 dp(i) = dp(i-1) + dp(i-2) 를 활용해서 반복문으로 하나씩 경우의 수를 기록, 
값이 매우 커질 수 있기 때문에 1007로 나눈 나머지값을 넣고 출력
## 복잡도

* 시간복잡도: O(n)

## 채점 결과

![image](https://github.com/user-attachments/assets/ed20d405-e1a1-4d74-9008-0d84592ccd06)
