### PR TITLE
강두오 48일차 문제 풀이

### DIFF
--- a/duoh/BOJ/src/java_16456/Main.java
+++ b/duoh/BOJ/src/java_16456/Main.java
@@ -1,0 +1,26 @@
+package java_16456;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+public class Main {
+    private static final int MOD = 1_000_000_009;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        int n = Integer.parseInt(br.readLine());
+        int[] dp = new int[50_001];
+        dp[1] = 1;
+        dp[2] = 1;
+        dp[3] = 2;
+
+        for (int i = 4; i <= n; i++) {
+            dp[i] = (dp[i - 1] + dp[i - 3]) % MOD;
+        }
+
+        System.out.println(dp[n]);
+        br.close();
+    }
+}


### PR DESCRIPTION
## 문제

[16456 하와와 대학생쨩 하와이로 가는 거시와요~](https://www.acmicpc.net/problem/16456)

## 풀이

### 풀이에 대한 직관적인 설명

- 열도를 여행하는 방법은 세 가지가 있다.
  - 다음 섬으로 이동, 다다음 섬으로 이동, 이전 섬으로 이동
  - 단, 방문했던 섬은 재방문하지 않는다.
- 열도의 섬 n개가 주어질 때, 여행할 수 있는 방법의 수를 출력하는 문제이다.

> 아.. 문제 읽기가 너무 어렵네요ㅡ

### 풀이 도출 과정

- 노가다로 구한.. 점화식 `dp[i] = dp[i - 1] + dp[i - 3]`

## 복잡도

* 시간복잡도: O(n)


## 채점 결과
<img width="940" alt="스크린샷 2024-11-12 오후 5 39 00" src="https://github.com/user-attachments/assets/d162e385-f5fd-49d0-bdd3-fb217e5e125d">

> dp 배열의 크기를 `n + 1` 로 했었는데, 인덱스 오류가 계속 나서 50_001로 바꾸니 되네요..?
