### PR TITLE
오동재 48일차 문제 풀이

### DIFF
--- a/dongjae/BOJ/src/java_2293/Main.java
+++ b/dongjae/BOJ/src/java_2293/Main.java
@@ -1,0 +1,32 @@
+package java_2293;
+
+import java.util.*;
+import java.io.*;
+
+public class Main {
+    public static int n, k;
+    public static int[] arr;
+    public static int[] dp;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        n = Integer.parseInt(st.nextToken());
+        k = Integer.parseInt(st.nextToken());
+
+        arr = new int[n+1];
+        dp = new int[k+1];
+        dp[0] = 1;
+
+        for (int i = 1; i <= n; i++) {
+            arr[i] = Integer.parseInt(br.readLine());
+            for (int j = arr[i]; j <= k; j++) {
+                int r = j - arr[i];
+                dp[j] += dp[r];
+            }
+        }
+
+        System.out.println(dp[k]);
+    }
+}


### PR DESCRIPTION
## 문제

[2293 동전 1](https://www.acmicpc.net/problem/2293)
<!-- 문제 제목이랑 링크를 달아주세요 -->

## 풀이

### 풀이에 대한 직관적인 설명

점화식은 쉽게 구했으나...중복 처리에서 애를 먹었다.

### 풀이 도출 과정

순서를 고려하지 않는 조합이기 때문에 순서를 무시하는 방법이 필요했다. 

수학에서 순열의 순서를 무시하기 위해 서로 다른 값들을 가지는 수들의 팩토리얼로 나누어 주면 되지만 이를 프로그램으로 구현하자니 또 복잡했다.

따라서 새로운 방법으로 동전을 중심으로 반복문을 구성하여 한 번 계산한 동전의 종류는 다시 등장하지 않게끔 로직을 수정하여 풀이하였다.

## 복잡도

<!-- 푼 알고리즘에 대한 시간복잡도 작성 -->

* 시간복잡도: O(n*k)

<!-- 위와 같이 복잡도를 산정하게 된 이유 -->

동전의 수만큼 dp 배열을 재저장하므로 O(n*k)

## 채점 결과

<!-- 문제 푼 결과 캡처 -->

<img width="860" alt="Screenshot 2024-11-13 at 5 07 23 PM" src="https://github.com/user-attachments/assets/26b1be5c-8283-4123-b7cb-b9c9358969f8">
