### PR TITLE
오동재 50일차 문제 풀이

### DIFF
--- a/dongjae/BOJ/src/java_15650/Main.java
+++ b/dongjae/BOJ/src/java_15650/Main.java
@@ -1,0 +1,46 @@
+package java_15650;
+
+import java.util.*;
+import java.io.*;
+
+public class Main {
+    public static int n, m;
+    public static int[] arr;
+    public static boolean[] visited;
+    public static StringBuilder sb = new StringBuilder();
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        n = Integer.parseInt(st.nextToken());
+        m = Integer.parseInt(st.nextToken());
+
+        arr = new int[n];
+        for (int i = 0; i < n; i++) {
+            arr[i] = i + 1;
+        }
+
+        visited = new boolean[n];
+
+        comb(0, 0);
+
+        System.out.println(sb);
+    }
+
+    public static void comb(int start, int depth) {
+        if (depth == m) {
+            for (int i = 0; i < n; i++) {
+                if (visited[i]) sb.append(arr[i]).append(" ");
+            }
+            sb.append("\n");
+            return;
+        }
+
+        for (int i = start; i < n; i++) {
+            visited[i] = true;
+            comb(i + 1, depth + 1);
+            visited[i] = false;
+        }
+    }
+}


### PR DESCRIPTION
## 문제

[15649 N과 M (2)](https://www.acmicpc.net/problem/15649)
<!-- 문제 제목이랑 링크를 달아주세요 -->

## 풀이

### 풀이에 대한 직관적인 설명

앞선 문제에서 순열이 아닌 조합의 관점으로 접근하여 풀이한다.

### 풀이 도출 과정

1부터 n까지 길이가 m인 순열을 구하는 방법에서 재귀 함수에 인자를 하나 더 추가하여 남은 숫자 중 선택할 수 있는 범위를 제한한다.

예를 들어 3을 배열의 첫번째 원소로 선택했다면 기존에는 3을 제외한 1부터 n까지 수 중에서 두번째 원소로 하나를 선택할 수 있었지만 이번에는 4부터 n까지로 범위를 제한한다.

## 복잡도

<!-- 푼 알고리즘에 대한 시간복잡도 작성 -->

* 시간복잡도: 도출 되는 조합의 수만큼 비례. 최악의 경우 O(2^n)

<!-- 위와 같이 복잡도를 산정하게 된 이유 --> 

도출되는 조합의 수만큼 재귀함수가 호출되기 때문에 m의 크기에 따라 최악의 경우 O(2^n)만큼 커질 수 있다.

## 채점 결과

<!-- 문제 푼 결과 캡처 -->

<img width="860" alt="Screenshot 2024-11-18 at 5 58 47 PM" src="https://github.com/user-attachments/assets/dfe3847a-6b94-4cdf-9ca2-d84cb215d236">
