### PR TITLE
오동재 51일차 문제 풀이

### DIFF
--- a/dongjae/BOJ/src/java_15651/Main.java
+++ b/dongjae/BOJ/src/java_15651/Main.java
@@ -1,0 +1,39 @@
+package java_15651;
+
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    public static int n, m;
+    public static int[] arr;
+    public static StringBuilder sb = new StringBuilder();
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        n = Integer.parseInt(st.nextToken());
+        m = Integer.parseInt(st.nextToken());
+
+        arr = new int[m];
+
+        dfs(0);
+
+        System.out.println(sb);
+    }
+
+    public static void dfs(int depth) {
+        if (depth == m) {
+            for (int i = 0; i < m; i++) {
+                sb.append(arr[i]).append(" ");
+            }
+            sb.append("\n");
+            return;
+        }
+
+        for (int i = 0; i < n; i++) {
+            arr[depth] = i + 1;
+            dfs(depth + 1);
+        }
+    }
+}


### PR DESCRIPTION
## 문제

[15651 N과 M (3)](https://www.acmicpc.net/problem/15651)
<!-- 문제 제목이랑 링크를 달아주세요 -->

## 풀이

### 풀이에 대한 직관적인 설명

1번 문제에서 중복만 포함하면 되기 때문에 `visited` 배열을 따로 처리하지 않기만 하면 된다.

### 풀이 도출 과정

재귀함수를 이용하는 원리는 동일하다. 

다만 중복을 허용하기 때문에 반복문을 매번 1부터 n까지로 범위를 상정한다.

## 복잡도

<!-- 푼 알고리즘에 대한 시간복잡도 작성 -->

* 시간복잡도: O(n^m)

<!-- 위와 같이 복잡도를 산정하게 된 이유 --> 

깊이가 m에 도달할 때까지 매번 n번의 반복문을 실행하기 때문에.

## 채점 결과

<!-- 문제 푼 결과 캡처 -->

<img width="857" alt="Screenshot 2024-11-19 at 1 29 59 PM" src="https://github.com/user-attachments/assets/614a380d-6fec-45a2-8d4d-08bf34676c16">
