### PR TITLE
오동재 52일차 문제 풀이

### DIFF
--- a/dongjae/BOJ/src/java_15652/Main.java
+++ b/dongjae/BOJ/src/java_15652/Main.java
@@ -1,0 +1,39 @@
+package java_15652;
+
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    public static int n, m;
+    public static int[] arr;
+    public static StringBuilder sb = new StringBuilder();
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        n = Integer.parseInt(st.nextToken());
+        m = Integer.parseInt(st.nextToken());
+
+        arr = new int[m];
+
+        dfs(1, 0);
+
+        System.out.println(sb);
+    }
+
+    public static void dfs(int start, int depth) {
+        if (depth == m) {
+            for (int i = 0; i < m; i++) {
+                sb.append(arr[i]).append(" ");
+            }
+            sb.append("\n");
+            return;
+        }
+
+        for (int i = start; i <= n; i++) {
+            arr[depth] = i;
+            dfs(i, depth + 1);
+        }
+    }
+}


### PR DESCRIPTION
## 문제

[15652 N과 M (4)](https://www.acmicpc.net/problem/15652)
<!-- 문제 제목이랑 링크를 달아주세요 -->

## 풀이

### 풀이에 대한 직관적인 설명

앞선 문제들과 같은 백트래킹 문제인데 중복을 허용하고 순서가 항상 오름차순인 수열을 구해야 한다.

### 풀이 도출 과정

배열의 남은 선택지를 고려할 때 범위를 자기 자신부터 끝까지로 항상 고려하면 된다.

## 복잡도

<!-- 푼 알고리즘에 대한 시간복잡도 작성 -->

* 시간복잡도: O(n^m)

<!-- 위와 같이 복잡도를 산정하게 된 이유 --> 

깊이가 m이 될 때까지 반복문을 n번 수행한다.

## 채점 결과

<!-- 문제 푼 결과 캡처 -->

<img width="859" alt="Screenshot 2024-11-19 at 3 33 44 PM" src="https://github.com/user-attachments/assets/0ba7bd51-a904-4ad8-898b-361e05cbab71">
