### PR TITLE
오동재 53일차 문제 풀이

### DIFF
--- a/dongjae/BOJ/src/java_15654/Main.java
+++ b/dongjae/BOJ/src/java_15654/Main.java
@@ -1,0 +1,54 @@
+package java_15654;
+
+import java.util.*;
+import java.io.*;
+
+public class Main {
+    public static int n, m;
+    public static List<Integer> origin = new ArrayList<>();
+    public static boolean[] visited;
+    public static int[] arr;
+    public static StringBuilder sb = new StringBuilder();
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        n = Integer.parseInt(st.nextToken());
+        m = Integer.parseInt(st.nextToken());
+
+        visited = new boolean[n+1];
+        arr = new int[m];
+
+        origin.add(0);
+        st = new StringTokenizer(br.readLine());
+        for (int i = 1; i <= n; i++) {
+            origin.add(Integer.parseInt(st.nextToken()));
+        }
+
+        Collections.sort(origin);
+
+        dfs(0);
+
+        System.out.println(sb);
+    }
+
+    public static void dfs(int depth) {
+        if (depth == m) {
+            for (int i = 0; i < m; i++) {
+                sb.append(arr[i]).append(" ");
+            }
+            sb.append("\n");
+            return;
+        }
+
+        for (int i = 1; i <= n; i++) {
+            if (!visited[i]) {
+                visited[i] = true;
+                arr[depth] = origin.get(i);
+                dfs(depth + 1);
+                visited[i] = false;
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 문제

[15654 N과 M (5)](https://www.acmicpc.net/problem/15654)
<!-- 문제 제목이랑 링크를 달아주세요 -->

## 풀이

### 풀이에 대한 직관적인 설명

해당 시리즈 1번 문제와 매우 같은 문제

### 풀이 도출 과정

1번 문제에서 1부터 n까지의 수열이 아니라 입력받은 수열을 정렬한 후 백트래킹을 이용해서 방문한 수를 제외하고 탐색하여 풀이한다.

## 복잡도

<!-- 푼 알고리즘에 대한 시간복잡도 작성 -->

* 시간복잡도: O(n^m)

<!-- 위와 같이 복잡도를 산정하게 된 이유 --> 

깊이가 m이 될때까지 반복문을 n번 반복한다.

## 채점 결과

<!-- 문제 푼 결과 캡처 -->

<img width="859" alt="Screenshot 2024-11-20 at 10 16 26 PM" src="https://github.com/user-attachments/assets/95d365d0-c1fd-44d8-a0e8-b35fb8775037">

