### PR TITLE
오동재 54일차 문제 풀이

### DIFF
--- a/dongjae/BOJ/src/java_2252/Main.java
+++ b/dongjae/BOJ/src/java_2252/Main.java
@@ -1,0 +1,64 @@
+package java_2252;
+
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    public static int n, m;
+    public static ArrayList<ArrayList<Integer>> graph = new ArrayList<>();
+    public static int[] indegree;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        n = Integer.parseInt(st.nextToken());
+        m = Integer.parseInt(st.nextToken());
+
+        indegree = new int[n+1];
+
+        for (int i = 0; i <= n; i++) {
+            graph.add(new ArrayList<Integer>());
+        }
+
+        for (int i = 0; i < m; i++) {
+            st = new StringTokenizer(br.readLine());
+            int a = Integer.parseInt(st.nextToken());
+            int b = Integer.parseInt(st.nextToken());
+
+            graph.get(a).add(b);
+            indegree[b] += 1;
+        }
+
+        ArrayList<Integer> answer = topologySort();
+
+        StringBuilder sb = new StringBuilder();
+        for (int x : answer) {
+            sb.append(x).append(" ");
+        }
+
+        System.out.println(sb);
+    }
+
+    public static ArrayList<Integer> topologySort() {
+        ArrayList<Integer> result = new ArrayList<>();
+        Queue<Integer> q = new LinkedList<>();
+
+        for (int i = 1; i <= n; i++) {
+            if (indegree[i] == 0) q.offer(i);
+        }
+
+        while (!q.isEmpty()) {
+            int now = q.poll();
+            result.add(now);
+            for (int i = 0; i < graph.get(now).size(); i++) {
+                indegree[graph.get(now).get(i)] -= 1;
+                if (indegree[graph.get(now).get(i)] == 0) {
+                    q.offer(graph.get(now).get(i));
+                }
+            }
+        }
+
+        return result;
+    }
+}


### PR DESCRIPTION
## 문제

[2252 줄 세우기](https://www.acmicpc.net/problem/2252)
<!-- 문제 제목이랑 링크를 달아주세요 -->

## 풀이

### 풀이에 대한 직관적인 설명

위상정렬 기본 문제

### 풀이 도출 과정

인접 리스트 방식으로 그래프를 저장하고 간선 정보와 진입 차수, 큐를 활용하여 위상정렬을 구현한다.

1. 진입차수가 0인 노드를 큐에 삽입한다.
2. 큐가 빌 때까지 다음 과정을 반복한다
    * 큐에서 원소를 꺼내 해당 노드에서 출발하는 간선 그래프를 제거한다.
    * 새롭게 진입차수가 0이 된 노드를 큐에 삽입한다.

## 복잡도

<!-- 푼 알고리즘에 대한 시간복잡도 작성 -->

* 시간복잡도: O(N + M)

<!-- 위와 같이 복잡도를 산정하게 된 이유 --> 

차례대로 모든 노드를 확인하면서 해당 노드에서 출발하는 간선을 차례대로 제거하기 때문이다.

## 채점 결과

<!-- 문제 푼 결과 캡처 -->

<img width="858" alt="Screenshot 2024-11-21 at 5 22 32 PM" src="https://github.com/user-attachments/assets/891342d8-0531-4cd4-98fb-e97e3bcba36c">
