### PR TITLE
오동재 56일차 문제 풀이

### DIFF
--- a/dongjae/BOJ/src/java_1766/Main.java
+++ b/dongjae/BOJ/src/java_1766/Main.java
@@ -1,0 +1,65 @@
+package java_1766;
+
+import java.util.*;
+import java.io.*;
+
+public class Main {
+    public static int n, m;
+    public static int[] indegree;
+    public static ArrayList<ArrayList<Integer>> graph = new ArrayList<ArrayList<Integer>>();
+    public static ArrayList<Integer> result = new ArrayList<>();
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        n = Integer.parseInt(st.nextToken());
+        m = Integer.parseInt(st.nextToken());
+
+        indegree = new int[n+1];
+
+        for (int i = 0; i <= n; i++) {
+            graph.add(new ArrayList<Integer>());
+        }
+
+        for (int i = 0; i < m; i++) {
+            st = new StringTokenizer(br.readLine());
+            int a = Integer.parseInt(st.nextToken());
+            int b = Integer.parseInt(st.nextToken());
+
+            graph.get(a).add(b);
+            indegree[b] += 1;
+        }
+
+        topologySort();
+
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < n; i++) {
+            sb.append(result.get(i)).append(" ");
+        }
+
+        System.out.println(sb);
+    }
+
+    public static void topologySort() {
+        PriorityQueue<Integer> q = new PriorityQueue<>();
+
+        for (int i = 1; i <= n; i++) {
+            if (indegree[i] == 0) {
+                q.offer(i);
+            }
+        }
+
+        while (!q.isEmpty()) {
+            int now = q.poll();
+            result.add(now);
+            for (int i = 0; i < graph.get(now).size(); i++) {
+                int next = graph.get(now).get(i);
+                indegree[next] -= 1;
+                if (indegree[next] == 0) {
+                    q.offer(next);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 문제

[1766 문제집](https://www.acmicpc.net/problem/1766)
<!-- 문제 제목이랑 링크를 달아주세요 -->

## 풀이

### 풀이에 대한 직관적인 설명

위상정렬 + 우선순위 큐

### 풀이 도출 과정

위상정렬과 풀이 방법은 동일하나 일반 큐 대신에 우선순위 큐를 활용해야 한다.

진입차수가 0인 노드들은 모두 큐에 삽입이 되고 큐에서 삽입된 노드들 중 가장 작은 수를 골라야만 3번 조건을 만족 시킬 수 있다.

## 복잡도

<!-- 푼 알고리즘에 대한 시간복잡도 작성 -->

* 시간복잡도: `O(m + nlogn)`

<!-- 위와 같이 복잡도를 산정하게 된 이유 --> 

모든 간선과 정점을 방문하며 하나의 노드가 큐에 삽입되고 삭제될 때마다 `O(logn)`의 시간이 걸린다.

## 채점 결과

<!-- 문제 푼 결과 캡처 -->

<img width="860" alt="Screenshot 2024-11-26 at 10 39 22 AM" src="https://github.com/user-attachments/assets/82632b61-21c6-45a4-a15a-2f8b69c2f77a">
